### PR TITLE
Sanitise filenames before writing files

### DIFF
--- a/data/Chaos/blades_of_khorne_bloodbound.json
+++ b/data/Chaos/blades_of_khorne_bloodbound.json
@@ -8,7 +8,7 @@
         "points": 65,
         "runemarks": [],
         "toughness": 3,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 3,
@@ -31,7 +31,7 @@
         "points": 65,
         "runemarks": [],
         "toughness": 3,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -56,7 +56,7 @@
             "bulwark"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 3,
@@ -79,7 +79,7 @@
         "points": 110,
         "runemarks": [],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 3,
@@ -102,7 +102,7 @@
         "points": 110,
         "runemarks": [],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -127,7 +127,7 @@
             "hero"
         ],
         "toughness": 3,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 5,
@@ -152,7 +152,7 @@
             "destroyer"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -178,7 +178,7 @@
             "bulwark"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -203,7 +203,7 @@
             "frenzied"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 5,
@@ -229,7 +229,7 @@
             "icon-bearer"
         ],
         "toughness": 5,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 3,
@@ -255,7 +255,7 @@
             "destroyer"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -280,7 +280,7 @@
             "hero"
         ],
         "toughness": 5,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -306,7 +306,7 @@
             "trapper"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -340,7 +340,7 @@
             "beast"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -365,7 +365,7 @@
             "hero"
         ],
         "toughness": 5,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 2,
@@ -390,7 +390,7 @@
             "hero"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 3,
@@ -415,7 +415,7 @@
             "hero"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -441,7 +441,7 @@
             "Priest"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -476,7 +476,7 @@
             "Priest"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 3,
@@ -501,7 +501,7 @@
             "ferocious"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 3,
@@ -526,7 +526,7 @@
             "mount"
         ],
         "toughness": 6,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 3,
@@ -551,7 +551,7 @@
             "mount"
         ],
         "toughness": 6,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -577,7 +577,7 @@
             "frenzied"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 6,
@@ -603,7 +603,7 @@
             "champion"
         ],
         "toughness": 5,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 5,
@@ -629,7 +629,7 @@
             "mount"
         ],
         "toughness": 6,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 5,
@@ -652,7 +652,7 @@
         "points": 80,
         "runemarks": [],
         "toughness": 3,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -675,7 +675,7 @@
         "points": 80,
         "runemarks": [],
         "toughness": 3,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -700,7 +700,7 @@
             "berserker"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -723,7 +723,7 @@
         "points": 135,
         "runemarks": [],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 3,
@@ -748,7 +748,7 @@
             "hero"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 5,
@@ -773,7 +773,7 @@
             "bulwark"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 3,
@@ -798,7 +798,7 @@
             "bulwark"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 3,
@@ -823,7 +823,7 @@
             "hero"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,
@@ -848,7 +848,7 @@
             "beast"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Bloodbound",
+        "warband": "Blades of Khorne: Bloodbound",
         "weapons": [
             {
                 "attacks": 4,

--- a/data/Chaos/blades_of_khorne_daemons.json
+++ b/data/Chaos/blades_of_khorne_daemons.json
@@ -10,7 +10,7 @@
             "frenzied"
         ],
         "toughness": 3,
-        "warband": "Blades of Khorne Daemons",
+        "warband": "Blades of Khorne: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -36,7 +36,7 @@
             "frenzied"
         ],
         "toughness": 3,
-        "warband": "Blades of Khorne Daemons",
+        "warband": "Blades of Khorne: Daemons",
         "weapons": [
             {
                 "attacks": 5,
@@ -62,7 +62,7 @@
             "frenzied"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Daemons",
+        "warband": "Blades of Khorne: Daemons",
         "weapons": [
             {
                 "attacks": 5,
@@ -88,7 +88,7 @@
             "mounted"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Daemons",
+        "warband": "Blades of Khorne: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -114,7 +114,7 @@
             "beast"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Daemons",
+        "warband": "Blades of Khorne: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -141,7 +141,7 @@
             "mounted"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Daemons",
+        "warband": "Blades of Khorne: Daemons",
         "weapons": [
             {
                 "attacks": 5,
@@ -168,7 +168,7 @@
             "ferocious"
         ],
         "toughness": 4,
-        "warband": "Blades of Khorne Daemons",
+        "warband": "Blades of Khorne: Daemons",
         "weapons": [
             {
                 "attacks": 5,
@@ -195,7 +195,7 @@
             "mount"
         ],
         "toughness": 5,
-        "warband": "Blades of Khorne Daemons",
+        "warband": "Blades of Khorne: Daemons",
         "weapons": [
             {
                 "attacks": 5,

--- a/data/Chaos/chaos_monster.json
+++ b/data/Chaos/chaos_monster.json
@@ -17,8 +17,8 @@
                 "attacks": 4,
                 "dmg_crit": 8,
                 "dmg_hit": 4,
-                "max_range": 1,
-                "min_range": 2,
+                "max_range": 2,
+                "min_range": 0,
                 "runemark": "unarmed",
                 "strength": 4
             }
@@ -43,8 +43,8 @@
                 "attacks": 4,
                 "dmg_crit": 8,
                 "dmg_hit": 4,
-                "max_range": 1,
-                "min_range": 2,
+                "max_range": 2,
+                "min_range": 0,
                 "runemark": "club",
                 "strength": 5
             }
@@ -70,7 +70,7 @@
                 "dmg_crit": 8,
                 "dmg_hit": 4,
                 "max_range": 1,
-                "min_range": 1,
+                "min_range": 0,
                 "runemark": "fangs",
                 "strength": 4
             }
@@ -95,8 +95,8 @@
                 "attacks": 5,
                 "dmg_crit": 10,
                 "dmg_hit": 4,
-                "max_range": 1,
-                "min_range": 2,
+                "max_range": 2,
+                "min_range": 0,
                 "runemark": "unarmed",
                 "strength": 6
             }
@@ -121,8 +121,8 @@
                 "attacks": 5,
                 "dmg_crit": 10,
                 "dmg_hit": 4,
-                "max_range": 1,
-                "min_range": 2,
+                "max_range": 2,
+                "min_range": 0,
                 "runemark": "claws",
                 "strength": 4
             }
@@ -147,8 +147,8 @@
                 "attacks": 5,
                 "dmg_crit": 8,
                 "dmg_hit": 4,
-                "max_range": 1,
-                "min_range": 2,
+                "max_range": 2,
+                "min_range": 0,
                 "runemark": "claws",
                 "strength": 4
             }
@@ -174,8 +174,8 @@
                 "attacks": 6,
                 "dmg_crit": 10,
                 "dmg_hit": 5,
-                "max_range": 1,
-                "min_range": 2,
+                "max_range": 2,
+                "min_range": 0,
                 "runemark": "fangs",
                 "strength": 6
             }

--- a/data/Chaos/disciples_of_tzeentch_arcanites.json
+++ b/data/Chaos/disciples_of_tzeentch_arcanites.json
@@ -8,7 +8,7 @@
         "points": 75,
         "runemarks": [],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 3,
@@ -31,7 +31,7 @@
         "points": 80,
         "runemarks": [],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 2,
@@ -56,7 +56,7 @@
             "brute"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 4,
@@ -79,7 +79,7 @@
         "points": 90,
         "runemarks": [],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 4,
@@ -111,7 +111,7 @@
         "points": 90,
         "runemarks": [],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 3,
@@ -143,7 +143,7 @@
         "points": 95,
         "runemarks": [],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 3,
@@ -175,7 +175,7 @@
         "points": 95,
         "runemarks": [],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 2,
@@ -207,7 +207,7 @@
         "points": 95,
         "runemarks": [],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 2,
@@ -239,7 +239,7 @@
         "points": 105,
         "runemarks": [],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 3,
@@ -264,7 +264,7 @@
             "hero"
         ],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 2,
@@ -298,7 +298,7 @@
             "hero"
         ],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 3,
@@ -323,7 +323,7 @@
             "destroyer"
         ],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 4,
@@ -348,7 +348,7 @@
             "hero"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 3,
@@ -383,7 +383,7 @@
             "berserker"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 3,
@@ -418,7 +418,7 @@
             "destroyer"
         ],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 5,
@@ -443,7 +443,7 @@
             "hero"
         ],
         "toughness": 5,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 4,
@@ -478,7 +478,7 @@
             "destroyer"
         ],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 4,
@@ -504,7 +504,7 @@
             "ferocious"
         ],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 4,
@@ -539,7 +539,7 @@
             "frenzied"
         ],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 4,
@@ -574,7 +574,7 @@
             "hero"
         ],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 4,
@@ -609,7 +609,7 @@
             "hero"
         ],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 4,
@@ -645,7 +645,7 @@
             "champion"
         ],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 4,
@@ -672,7 +672,7 @@
             "berserker"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 4,
@@ -708,7 +708,7 @@
             "fly"
         ],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 5,
@@ -735,7 +735,7 @@
             "frenzied"
         ],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 4,
@@ -769,7 +769,7 @@
             "minion"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 3,
@@ -803,7 +803,7 @@
             "warrior"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 3,
@@ -835,7 +835,7 @@
         "points": 110,
         "runemarks": [],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 3,
@@ -867,7 +867,7 @@
         "points": 110,
         "runemarks": [],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 3,
@@ -901,7 +901,7 @@
             "elite"
         ],
         "toughness": 4,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 3,
@@ -926,7 +926,7 @@
             "hero"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Arcanites",
+        "warband": "Disciples of Tzeentch: Arcanites",
         "weapons": [
             {
                 "attacks": 3,

--- a/data/Chaos/disciples_of_tzeentch_daemons.json
+++ b/data/Chaos/disciples_of_tzeentch_daemons.json
@@ -10,7 +10,7 @@
             "minion"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Daemons",
+        "warband": "Disciples of Tzeentch: Daemons",
         "weapons": [
             {
                 "attacks": 3,
@@ -44,7 +44,7 @@
             "warrior"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Daemons",
+        "warband": "Disciples of Tzeentch: Daemons",
         "weapons": [
             {
                 "attacks": 3,
@@ -78,7 +78,7 @@
             "elite"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Daemons",
+        "warband": "Disciples of Tzeentch: Daemons",
         "weapons": [
             {
                 "attacks": 3,
@@ -113,7 +113,7 @@
             "destroyer"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Daemons",
+        "warband": "Disciples of Tzeentch: Daemons",
         "weapons": [
             {
                 "attacks": 3,
@@ -148,7 +148,7 @@
             "destroyer"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Daemons",
+        "warband": "Disciples of Tzeentch: Daemons",
         "weapons": [
             {
                 "attacks": 2,
@@ -183,7 +183,7 @@
             "berserker"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Daemons",
+        "warband": "Disciples of Tzeentch: Daemons",
         "weapons": [
             {
                 "attacks": 2,
@@ -218,7 +218,7 @@
             "elite"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Daemons",
+        "warband": "Disciples of Tzeentch: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -254,7 +254,7 @@
             "berserker"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Daemons",
+        "warband": "Disciples of Tzeentch: Daemons",
         "weapons": [
             {
                 "attacks": 2,
@@ -290,7 +290,7 @@
             "beast"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Daemons",
+        "warband": "Disciples of Tzeentch: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -316,7 +316,7 @@
             "berserker"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Daemons",
+        "warband": "Disciples of Tzeentch: Daemons",
         "weapons": [
             {
                 "attacks": 2,
@@ -352,7 +352,7 @@
             "mystic"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Daemons",
+        "warband": "Disciples of Tzeentch: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -388,7 +388,7 @@
             "mystic"
         ],
         "toughness": 3,
-        "warband": "Disciples of Tzeentch Daemons",
+        "warband": "Disciples of Tzeentch: Daemons",
         "weapons": [
             {
                 "attacks": 3,

--- a/data/Chaos/hedonites_of_slaanesh_daemons.json
+++ b/data/Chaos/hedonites_of_slaanesh_daemons.json
@@ -10,7 +10,7 @@
             "warrior"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Daemons",
+        "warband": "Hedonites of Slaanesh: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -36,7 +36,7 @@
             "warrior"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Daemons",
+        "warband": "Hedonites of Slaanesh: Daemons",
         "weapons": [
             {
                 "attacks": 5,
@@ -62,7 +62,7 @@
             "mount"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Daemons",
+        "warband": "Hedonites of Slaanesh: Daemons",
         "weapons": [
             {
                 "attacks": 3,
@@ -87,7 +87,7 @@
             "mount"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Daemons",
+        "warband": "Hedonites of Slaanesh: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -113,7 +113,7 @@
             "mount"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Daemons",
+        "warband": "Hedonites of Slaanesh: Daemons",
         "weapons": [
             {
                 "attacks": 5,
@@ -139,7 +139,7 @@
             "warrior"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Daemons",
+        "warband": "Hedonites of Slaanesh: Daemons",
         "weapons": [
             {
                 "attacks": 5,
@@ -173,7 +173,7 @@
             "agile"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Daemons",
+        "warband": "Hedonites of Slaanesh: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -199,7 +199,7 @@
             "mystic"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Daemons",
+        "warband": "Hedonites of Slaanesh: Daemons",
         "weapons": [
             {
                 "attacks": 3,
@@ -235,7 +235,7 @@
             "mount"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Daemons",
+        "warband": "Hedonites of Slaanesh: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -262,7 +262,7 @@
             "mount"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Daemons",
+        "warband": "Hedonites of Slaanesh: Daemons",
         "weapons": [
             {
                 "attacks": 5,
@@ -288,7 +288,7 @@
             "agile"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Daemons",
+        "warband": "Hedonites of Slaanesh: Daemons",
         "weapons": [
             {
                 "attacks": 5,
@@ -313,7 +313,7 @@
             "hero"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Daemons",
+        "warband": "Hedonites of Slaanesh: Daemons",
         "weapons": [
             {
                 "attacks": 6,

--- a/data/Chaos/hedonites_of_slaanesh_sybarites.json
+++ b/data/Chaos/hedonites_of_slaanesh_sybarites.json
@@ -10,7 +10,7 @@
             "Priest"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 3,
@@ -35,7 +35,7 @@
             "minion"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 3,
@@ -69,7 +69,7 @@
             "warrior"
         ],
         "toughness": 5,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -94,7 +94,7 @@
             "berserker"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -119,7 +119,7 @@
             "berserker"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -145,7 +145,7 @@
             "mystic"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 3,
@@ -179,7 +179,7 @@
             "berserker"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 3,
@@ -204,7 +204,7 @@
             "Hero. Minion"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 3,
@@ -239,7 +239,7 @@
             "mount"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 3,
@@ -264,7 +264,7 @@
             "mount"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -290,7 +290,7 @@
             "mounted"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -325,7 +325,7 @@
             "warrior"
         ],
         "toughness": 5,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -351,7 +351,7 @@
             "mount"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 3,
@@ -377,7 +377,7 @@
             "berserker"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -402,7 +402,7 @@
             "ferocious"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -429,7 +429,7 @@
             "mount"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -456,7 +456,7 @@
             "mounted"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -492,7 +492,7 @@
             "mount"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -518,7 +518,7 @@
             "champion"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -544,7 +544,7 @@
             "ferocious"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -567,7 +567,7 @@
         "points": 105,
         "runemarks": [],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -592,7 +592,7 @@
             "minion"
         ],
         "toughness": 3,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 3,
@@ -626,7 +626,7 @@
             "ferocious"
         ],
         "toughness": 4,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,
@@ -652,7 +652,7 @@
             "warrior"
         ],
         "toughness": 5,
-        "warband": "Hedonites of Slaanesh Sybarites",
+        "warband": "Hedonites of Slaanesh: Sybarites",
         "weapons": [
             {
                 "attacks": 4,

--- a/data/Chaos/maggotkin_of_nurgle_daemons.json
+++ b/data/Chaos/maggotkin_of_nurgle_daemons.json
@@ -10,7 +10,7 @@
             "minion"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Daemons",
+        "warband": "Maggotkin of Nurgle: Daemons",
         "weapons": [
             {
                 "attacks": 3,
@@ -36,7 +36,7 @@
             "warrior"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Daemons",
+        "warband": "Maggotkin of Nurgle: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -61,7 +61,7 @@
             "minion"
         ],
         "toughness": 3,
-        "warband": "Maggotkin Of Nurgle Daemons",
+        "warband": "Maggotkin of Nurgle: Daemons",
         "weapons": [
             {
                 "attacks": 6,
@@ -86,7 +86,7 @@
             "hero"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Daemons",
+        "warband": "Maggotkin of Nurgle: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -121,7 +121,7 @@
             "agile"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Daemons",
+        "warband": "Maggotkin of Nurgle: Daemons",
         "weapons": [
             {
                 "attacks": 3,
@@ -147,7 +147,7 @@
             "champion"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Daemons",
+        "warband": "Maggotkin of Nurgle: Daemons",
         "weapons": [
             {
                 "attacks": 2,
@@ -173,7 +173,7 @@
             "ferocious"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Daemons",
+        "warband": "Maggotkin of Nurgle: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -199,7 +199,7 @@
             "destroyer"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Daemons",
+        "warband": "Maggotkin of Nurgle: Daemons",
         "weapons": [
             {
                 "attacks": 4,
@@ -226,7 +226,7 @@
             "destroyer"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Daemons",
+        "warband": "Maggotkin of Nurgle: Daemons",
         "weapons": [
             {
                 "attacks": 5,

--- a/data/Chaos/maggotkin_of_nurgle_rotbringers.json
+++ b/data/Chaos/maggotkin_of_nurgle_rotbringers.json
@@ -8,7 +8,7 @@
         "points": 110,
         "runemarks": [],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 3,
@@ -31,7 +31,7 @@
         "points": 110,
         "runemarks": [],
         "toughness": 5,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 2,
@@ -56,7 +56,7 @@
             "icon-bearer"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 3,
@@ -81,7 +81,7 @@
             "champion"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 4,
@@ -107,7 +107,7 @@
             "mystic"
         ],
         "toughness": 3,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 3,
@@ -141,7 +141,7 @@
             "hero"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 3,
@@ -167,7 +167,7 @@
             "bulwark"
         ],
         "toughness": 5,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 3,
@@ -192,7 +192,7 @@
             "hero"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 3,
@@ -219,7 +219,7 @@
             "mount"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 4,
@@ -245,7 +245,7 @@
             "fly"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 4,
@@ -272,7 +272,7 @@
             "destroyer"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 4,
@@ -295,7 +295,7 @@
         "points": 130,
         "runemarks": [],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 3,
@@ -320,7 +320,7 @@
             "beast"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 4,
@@ -346,7 +346,7 @@
             "mystic"
         ],
         "toughness": 4,
-        "warband": "Maggotkin Of Nurgle Rotbringers",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
         "weapons": [
             {
                 "attacks": 3,

--- a/data/Chaos/slaves_to_darkness.json
+++ b/data/Chaos/slaves_to_darkness.json
@@ -1012,7 +1012,7 @@
                 "dmg_crit": 4,
                 "dmg_hit": 1,
                 "max_range": 8,
-                "min_range": 2,
+                "min_range": 0,
                 "runemark": "ranged",
                 "strength": 4
             }

--- a/data/Death/royal_beastflayers.json
+++ b/data/Death/royal_beastflayers.json
@@ -1,0 +1,125 @@
+[
+    {
+        "_id": "8x3l1r2h",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 5,
+        "name": "Ghoul Tracker",
+        "points": 55,
+        "runemarks": [],
+        "toughness": 3,
+        "warband": "Royal Beastflayers",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 3,
+                "dmg_hit": 1,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "claws",
+                "strength": 3
+            }
+        ],
+        "wounds": 8
+    },
+    {
+        "_id": "5a7z9b1q",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 5,
+        "name": "Ghoul Gore-Squire",
+        "points": 95,
+        "runemarks": [
+            "champion"
+        ],
+        "toughness": 4,
+        "warband": "Royal Beastflayers",
+        "weapons": [
+            {
+                "attacks": 4,
+                "dmg_crit": 3,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "claws",
+                "strength": 3
+            }
+        ],
+        "wounds": 12
+    },
+    {
+        "_id": "m2n8v1f7",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 5,
+        "name": "Beastflayer Baron",
+        "points": 115,
+        "runemarks": [
+            "brute"
+        ],
+        "toughness": 4,
+        "warband": "Royal Beastflayers",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "claws",
+                "strength": 4
+            }
+        ],
+        "wounds": 16
+    },
+    {
+        "_id": "q2p6j4h9",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 7,
+        "name": "Offal Hound",
+        "points": 130,
+        "runemarks": [
+            "beast"
+        ],
+        "toughness": 3,
+        "warband": "Royal Beastflayers",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "claws",
+                "strength": 4
+            }
+        ],
+        "wounds": 18
+    },
+    {
+        "_id": "3c8m9kx1",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 5,
+        "name": "Royal Flaymaster",
+        "points": 175,
+        "runemarks": [
+            "hero"
+        ],
+        "toughness": 4,
+        "warband": "Royal Beastflayers",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 5,
+                "dmg_hit": 3,
+                "max_range": 2,
+                "min_range": 0,
+                "runemark": "claws",
+                "strength": 4
+            }
+        ],
+        "wounds": 20
+    }
+]

--- a/data/Death/soulblight_gravelords.json
+++ b/data/Death/soulblight_gravelords.json
@@ -79,7 +79,7 @@
         "bladeborn": "",
         "grand_alliance": "death",
         "movement": 3,
-        "name": "Grave Guard with Blade and Shield",
+        "name": "Grave Guard with Wight Blade and Crypt Shield",
         "points": 55,
         "runemarks": [
             "minion",

--- a/data/Destruction/destruction_monster.json
+++ b/data/Destruction/destruction_monster.json
@@ -16,8 +16,8 @@
                 "attacks": 3,
                 "dmg_crit": 8,
                 "dmg_hit": 4,
-                "max_range": 1,
-                "min_range": 2,
+                "max_range": 2,
+                "min_range": 0,
                 "runemark": "club",
                 "strength": 5
             }
@@ -42,8 +42,8 @@
                 "attacks": 4,
                 "dmg_crit": 8,
                 "dmg_hit": 4,
-                "max_range": 1,
-                "min_range": 2,
+                "max_range": 2,
+                "min_range": 0,
                 "runemark": "club",
                 "strength": 5
             }
@@ -69,7 +69,7 @@
                 "dmg_crit": 8,
                 "dmg_hit": 4,
                 "max_range": 1,
-                "min_range": 1,
+                "min_range": 0,
                 "runemark": "fangs",
                 "strength": 5
             }

--- a/data/Order/cities_of_sigmar.json
+++ b/data/Order/cities_of_sigmar.json
@@ -29,7 +29,7 @@
         "bladeborn": "",
         "grand_alliance": "order",
         "movement": 5,
-        "name": "Black Ark Cosair with Swords",
+        "name": "Black Ark Corsair with Swords",
         "points": 65,
         "runemarks": [],
         "toughness": 3,
@@ -198,7 +198,7 @@
         "bladeborn": "",
         "grand_alliance": "order",
         "movement": 5,
-        "name": "Black Ark Cosair with Sword & Handbow",
+        "name": "Black Ark Corsair with Sword & Handbow",
         "points": 75,
         "runemarks": [
             "scout"
@@ -830,7 +830,7 @@
                 "dmg_crit": 3,
                 "dmg_hit": 1,
                 "max_range": 8,
-                "min_range": 1,
+                "min_range": 0,
                 "runemark": "ranged",
                 "strength": 3
             }

--- a/data/Order/order_monster.json
+++ b/data/Order/order_monster.json
@@ -17,8 +17,8 @@
                 "attacks": 4,
                 "dmg_crit": 8,
                 "dmg_hit": 4,
-                "max_range": 1,
-                "min_range": 2,
+                "max_range": 2,
+                "min_range": 0,
                 "runemark": "fangs",
                 "strength": 5
             }
@@ -43,8 +43,8 @@
                 "attacks": 4,
                 "dmg_crit": 8,
                 "dmg_hit": 4,
-                "max_range": 1,
-                "min_range": 2,
+                "max_range": 2,
+                "min_range": 0,
                 "runemark": "fangs",
                 "strength": 5
             }

--- a/data/Order/stormcast_eternals_questor_soulsworn.json
+++ b/data/Order/stormcast_eternals_questor_soulsworn.json
@@ -1,0 +1,192 @@
+[
+    {
+        "_id": "6e1b7w9z",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 4,
+        "name": "Errant-Questor Duelist with Twinblades",
+        "points": 160,
+        "runemarks": [
+            "hero",
+            "champion"
+        ],
+        "toughness": 5,
+        "warband": "Stormcast Eternals Questor Soulsworn",
+        "weapons": [
+            {
+                "attacks": 5,
+                "dmg_crit": 3,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "sword",
+                "strength": 4
+            }
+        ],
+        "wounds": 20
+    },
+    {
+        "_id": "u4nyw6a2",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 4,
+        "name": "Errant-Questor with Grandblade",
+        "points": 165,
+        "runemarks": [
+            "hero",
+            "destroyer"
+        ],
+        "toughness": 5,
+        "warband": "Stormcast Eternals Questor Soulsworn",
+        "weapons": [
+            {
+                "attacks": 4,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "sword",
+                "strength": 5
+            }
+        ],
+        "wounds": 20
+    },
+    {
+        "_id": "s5v8g2y4",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 4,
+        "name": "Errant-Questor with Grandaxe",
+        "points": 165,
+        "runemarks": [
+            "hero",
+            "destroyer"
+        ],
+        "toughness": 5,
+        "warband": "Stormcast Eternals Questor Soulsworn",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 5,
+                "dmg_hit": 2,
+                "max_range": 2,
+                "min_range": 0,
+                "runemark": "axe",
+                "strength": 5
+            }
+        ],
+        "wounds": 20
+    },
+    {
+        "_id": "y9p4k7d1",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 4,
+        "name": "Errant-Questor with Grandhammer",
+        "points": 165,
+        "runemarks": [
+            "hero",
+            "destroyer"
+        ],
+        "toughness": 5,
+        "warband": "Stormcast Eternals Questor Soulsworn",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 4,
+                "dmg_hit": 3,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "hammer",
+                "strength": 6
+            }
+        ],
+        "wounds": 20
+    },
+    {
+        "_id": "j3h6t5r7",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 4,
+        "name": "Soulsworn Knight-Relictor",
+        "points": 165,
+        "runemarks": [
+            "hero",
+            "priest"
+        ],
+        "toughness": 5,
+        "warband": "Stormcast Eternals Questor Soulsworn",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 4,
+                "dmg_hit": 3,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "hammer",
+                "strength": 4
+            },
+            {
+                "attacks": 2,
+                "dmg_crit": 5,
+                "dmg_hit": 3,
+                "max_range": 8,
+                "min_range": 0,
+                "runemark": "blast",
+                "strength": 4
+            }
+        ],
+        "wounds": 20
+    },
+    {
+        "_id": "a7r5x8t9",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 4,
+        "name": "Questor-Prime",
+        "points": 170,
+        "runemarks": [
+            "hero",
+            "warrior"
+        ],
+        "toughness": 5,
+        "warband": "Stormcast Eternals Questor Soulsworn",
+        "weapons": [
+            {
+                "attacks": 4,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 2,
+                "min_range": 0,
+                "runemark": "axe",
+                "strength": 4
+            }
+        ],
+        "wounds": 20
+    },
+    {
+        "_id": "k9f3n1l6",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 4,
+        "name": "Errant-Questor with Grandspear",
+        "points": 170,
+        "runemarks": [
+            "hero"
+        ],
+        "toughness": 5,
+        "warband": "Stormcast Eternals Questor Soulsworn",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 5,
+                "dmg_hit": 2,
+                "max_range": 3,
+                "min_range": 0,
+                "runemark": "spear",
+                "strength": 5
+            }
+        ],
+        "wounds": 20
+    }
+]

--- a/python/data_parsing.py
+++ b/python/data_parsing.py
@@ -89,9 +89,11 @@ class FighterJSONPayload(FighterDataPayload):
             for warband, fighters in WARBANDS.items():
                 data_path = Path(dst_root, GA.lower())
                 filename = warband.lower().replace(' ', '_') + '.json'
+                for illegal_char in r'\\/:*?\"<>|':
+                    filename = str(filename).replace(illegal_char, '')
                 data_path.mkdir(parents=True, exist_ok=True)
                 output_file = Path(data_path, filename)
                 with open(output_file, 'w') as f:
-                    print(f'Writing {len(WARBANDS[warband])} fighters to {output_file}...')
+                    print(f'Writing {len(WARBANDS[warband])} fighters to {output_file}')
                     sorted_warband = sort_data(WARBANDS[warband])
                     json.dump(sorted_warband, f, ensure_ascii=True, indent=4, sort_keys=False)


### PR DESCRIPTION
This allows us to use colons (or other characters which are illegal in windows filepaths) in warband names.