### PR TITLE
Add Blacktalons

### DIFF
--- a/data/Order/the_blacktalons.json
+++ b/data/Order/the_blacktalons.json
@@ -1,0 +1,164 @@
+[
+    {
+        "_id": "fe3c9b45",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 4,
+        "name": "Hendrick, The Silver Wolf",
+        "points": 155,
+        "runemarks": [
+            "champion"
+        ],
+        "toughness": 5,
+        "warband": "The Blacktalons",
+        "weapons": [
+            {
+                "attacks": 4,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "sword",
+                "strength": 4
+            },
+            {
+                "attacks": 3,
+                "dmg_crit": 5,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "sword",
+                "strength": 5
+            }
+        ],
+        "wounds": 25
+    },
+    {
+        "_id": "5feaf59c",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 5,
+        "name": "Lorai, Child of the Abyss",
+        "points": 160,
+        "runemarks": [
+            "fly",
+            "mystic"
+        ],
+        "toughness": 3,
+        "warband": "The Blacktalons",
+        "weapons": [
+            {
+                "attacks": 2,
+                "dmg_crit": 3,
+                "dmg_hit": 1,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "dagger",
+                "strength": 3
+            },
+            {
+                "attacks": 3,
+                "dmg_crit": 7,
+                "dmg_hit": 3,
+                "max_range": 7,
+                "min_range": 3,
+                "runemark": "blast",
+                "strength": 3
+            }
+        ],
+        "wounds": 20
+    },
+    {
+        "_id": "349b6dfe",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 4,
+        "name": "Shakana Goldenblade",
+        "points": 180,
+        "runemarks": [
+            "destroyer"
+        ],
+        "toughness": 5,
+        "warband": "The Blacktalons",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "sword",
+                "strength": 4
+            },
+            {
+                "attacks": 4,
+                "dmg_crit": 2,
+                "dmg_hit": 1,
+                "max_range": 15,
+                "min_range": 3,
+                "runemark": "ranged",
+                "strength": 3
+            }
+        ],
+        "wounds": 25
+    },
+    {
+        "_id": "a0fb0704",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 4,
+        "name": "Rostus Oxenhammer",
+        "points": 200,
+        "runemarks": [
+            "champion"
+        ],
+        "toughness": 6,
+        "warband": "The Blacktalons",
+        "weapons": [
+            {
+                "attacks": 4,
+                "dmg_crit": 6,
+                "dmg_hit": 3,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "hammer",
+                "strength": 6
+            }
+        ],
+        "wounds": 25
+    },
+    {
+        "_id": "41cc2020",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 7,
+        "name": "Neave Blacktalon",
+        "points": 285,
+        "runemarks": [
+            "hero"
+        ],
+        "toughness": 5,
+        "warband": "The Blacktalons",
+        "weapons": [
+            {
+                "attacks": 6,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "axe",
+                "strength": 5
+            },
+            {
+                "attacks": 3,
+                "dmg_crit": 4,
+                "dmg_hit": 1,
+                "max_range": 10,
+                "min_range": 0,
+                "runemark": "ranged",
+                "strength": 4
+            }
+        ],
+        "wounds": 30
+    }
+]

--- a/data/abilities.json
+++ b/data/abilities.json
@@ -6187,6 +6187,54 @@
         ]
     },
     {
+        "_id": "af6705e7",
+        "name": "Shield of Azyr",
+        "warband": "Blacktalons",
+        "cost": "reaction",
+        "description": "A fighter can make this reaction after they are targeted by an attack action but before the hit rolls are made. Count up to two critical hits from that attack action as hits instead. If this fighter has the Hero runemark and is within 6\" of another friendly fighter with the Blacktalons runemark and the Champion or Destroyer runemark, count up to three critical hits from that attack action as hits instead.",
+        "runemarks": []
+    },
+    {
+        "_id": "f4925187",
+        "name": "Storm of Justice",
+        "warband": "Blacktalons",
+        "cost": "double",
+        "description": "Pick a visible friendly fighter with the Blacktalons runemark within a number of inches of this fighter equal to the value of this ability. That fighter makes a bonus move action or a bonus attack action.",
+        "runemarks": [
+            "champion"
+        ]
+    },
+    {
+        "_id": "cc2a11b5",
+        "name": "Headshot",
+        "warband": "Blacktalons",
+        "cost": "triple",
+        "description": "Add the value of this ability to the damage points allocated to enemy fighters by each hit and critical hit from the next ranged attack action made by this fighter in this activation.",
+        "runemarks": [
+            "destroyer"
+        ]
+    },
+    {
+        "_id": "ba962bd6",
+        "name": "Nebulous Sea-fog",
+        "warband": "Blacktalons",
+        "cost": "triple",
+        "description": "Until the end of the battle round, subtract 1 from the Attacks characteristic (to a minimum of 1) of attack actions made by enemy fighters while they are within 6\" of this fighter.",
+        "runemarks": [
+            "mystic"
+        ]
+    },
+    {
+        "_id": "a6ff68ea",
+        "name": "Windrider",
+        "warband": "Blacktalons",
+        "cost": "quad",
+        "description": "A fighter can only use this ability if an enemy fighter has been taken down by an attack action made by them this activation. Remove this fighter from the battlefield, then set this fighter up on a platform or the battlefield floor, more than 6\" from all enemy fighters. You can subtract the value of this ability from that 6\", to a minimum of 0.",
+        "runemarks": [
+            "hero"
+        ]
+    },
+    {
         "_id": "3382fbfd",
         "name": "The Chosen Kin",
         "warband": "The Chosen Axes",

--- a/data/fighters.json
+++ b/data/fighters.json
@@ -30499,6 +30499,168 @@
         "wounds": 20
     },
     {
+        "_id": "fe3c9b45",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 4,
+        "name": "Hendrick, The Silver Wolf",
+        "points": 155,
+        "runemarks": [
+            "champion"
+        ],
+        "toughness": 5,
+        "warband": "Blacktalons",
+        "weapons": [
+            {
+                "attacks": 4,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "sword",
+                "strength": 4
+            },
+            {
+                "attacks": 3,
+                "dmg_crit": 5,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "sword",
+                "strength": 5
+            }
+        ],
+        "wounds": 25
+    },
+    {
+        "_id": "5feaf59c",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 5,
+        "name": "Lorai, Child of the Abyss",
+        "points": 160,
+        "runemarks": [
+            "fly",
+            "mystic"
+        ],
+        "toughness": 3,
+        "warband": "Blacktalons",
+        "weapons": [
+            {
+                "attacks": 2,
+                "dmg_crit": 3,
+                "dmg_hit": 1,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "dagger",
+                "strength": 3
+            },
+            {
+                "attacks": 3,
+                "dmg_crit": 7,
+                "dmg_hit": 3,
+                "max_range": 7,
+                "min_range": 3,
+                "runemark": "blast",
+                "strength": 3
+            }
+        ],
+        "wounds": 20
+    },
+    {
+        "_id": "349b6dfe",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 4,
+        "name": "Shakana Goldenblade",
+        "points": 180,
+        "runemarks": [
+            "destroyer"
+        ],
+        "toughness": 5,
+        "warband": "Blacktalons",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "sword",
+                "strength": 4
+            },
+            {
+                "attacks": 4,
+                "dmg_crit": 2,
+                "dmg_hit": 1,
+                "max_range": 15,
+                "min_range": 3,
+                "runemark": "ranged",
+                "strength": 3
+            }
+        ],
+        "wounds": 25
+    },
+    {
+        "_id": "a0fb0704",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 4,
+        "name": "Rostus Oxenhammer",
+        "points": 200,
+        "runemarks": [
+            "champion"
+        ],
+        "toughness": 6,
+        "warband": "Blacktalons",
+        "weapons": [
+            {
+                "attacks": 4,
+                "dmg_crit": 6,
+                "dmg_hit": 3,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "hammer",
+                "strength": 6
+            }
+        ],
+        "wounds": 25
+    },
+    {
+        "_id": "41cc2020",
+        "bladeborn": "",
+        "grand_alliance": "order",
+        "movement": 7,
+        "name": "Neave Blacktalon",
+        "points": 285,
+        "runemarks": [
+            "hero"
+        ],
+        "toughness": 5,
+        "warband": "Blacktalons",
+        "weapons": [
+            {
+                "attacks": 6,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "axe",
+                "strength": 5
+            },
+            {
+                "attacks": 3,
+                "dmg_crit": 4,
+                "dmg_hit": 1,
+                "max_range": 10,
+                "min_range": 0,
+                "runemark": "ranged",
+                "strength": 4
+            }
+        ],
+        "wounds": 30
+    },
+    {
         "_id": "df9fe661",
         "bladeborn": "",
         "grand_alliance": "order",


### PR DESCRIPTION
This PR adds the fighters and abilities for the Blacktalons warband released via a [Warhammer Community article](https://www.warhammer-community.com/2023/11/01/put-the-blacktalons-to-work-hunting-down-foul-foes-with-free-downloadable-rules/).