### PR TITLE
(Order) Add missing Abyssal Howl ability

### DIFF
--- a/data/Order/order_abilities.json
+++ b/data/Order/order_abilities.json
@@ -43,6 +43,17 @@
             "berserker"
         ]
     },
+        {
+        "_id": "87348921",
+        "name": "Abyssal Howl",
+        "warband": "order",
+        "monster": "Kharibdyss",
+        "cost": "triple",
+        "description": "Roll a dice for each enemy fighter within a number of inches of this fighter equal to the value of this ability. On a roll of 3+, until the end of the battle round, the fighter being rolled for cannot make move actions or disengage actions.",
+        "runemarks": [
+            "berserker"
+        ]
+    },
     {
         "_id": "86b60a14",
         "name": "Spiked Tail",

--- a/data/Order/order_abilities.json
+++ b/data/Order/order_abilities.json
@@ -43,7 +43,7 @@
             "berserker"
         ]
     },
-        {
+    {
         "_id": "87348921",
         "name": "Abyssal Howl",
         "warband": "order",


### PR DESCRIPTION
Abyssal Howl from the Kharibdyss ability table in the Order compendium was missing. This PR adds it.