### PR TITLE
Capitalise Chimera, fix Terrorgheist Death Scream warband

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # IDE Project/env files
 /.idea/
 /venv/
+
+# local use only
+/python/test_script.py

--- a/data/Chaos/chaos_abilities.json
+++ b/data/Chaos/chaos_abilities.json
@@ -88,7 +88,7 @@
         "_id": "5966dc17",
         "name": "Tail Whip",
         "warband": "chaos",
-        "monster": "chimera",
+        "monster": "Chimera",
         "cost": "double",
         "description": "Pick a visible enemy fighter within 3\" of this fighter and roll a dice. On a roll of 4+, allocate 3 damage points to that fighter.",
         "runemarks": [
@@ -171,7 +171,7 @@
         "_id": "e19e1937",
         "name": "Leonine Roar",
         "warband": "chaos",
-        "monster": "chimera",
+        "monster": "Chimera",
         "cost": "triple",
         "description": "Until the end of the battle round, subtract 1 from the Attacks characteristic (to a minimum of 1) of attack actions made by enemy fighters while they are within 6\" of this fighter.",
         "runemarks": [
@@ -297,7 +297,7 @@
         "_id": "cd07297b",
         "name": "Draconic Head's Fiery Breath",
         "warband": "chaos",
-        "monster": "chimera",
+        "monster": "Chimera",
         "cost": "quad",
         "description": "Allocate a number of damage points equal to the value of this ability to all visible enemy fighters within 4\" of this fighter.",
         "runemarks": [
@@ -385,17 +385,6 @@
         "description": "A fighter can make this reaction after an enemy fighter finishes a move action on an open platform and within 3\" horizontally and 5\" vertically of this fighter. The controlling player for each fighter within 1/2\" of the edge of that platform must take a falling test, and on a roll of 1 or 2 that fighter falls.",
         "runemarks": [
             "destroyer"
-        ]
-    },
-    {
-        "_id": "a7e23cab",
-        "name": "Death Scream",
-        "warband": "chaos",
-        "monster": "Terrorgheist",
-        "cost": "triple",
-        "description": "Roll a dice for each visible enemy fighter within 8\" of this fighter. On a roll of 5, allocate 1 damage point to the fighter being rolled for. On a roll of 6, allocate a number of damage points to the fighter being rolled for equal to the value of this ability.",
-        "runemarks": [
-            "terrifying"
         ]
     },
     {

--- a/data/Death/death_abilities.json
+++ b/data/Death/death_abilities.json
@@ -32,6 +32,17 @@
         ]
     },
     {
+        "_id": "a7e23cab",
+        "name": "Death Scream",
+        "warband": "death",
+        "monster": "Terrorgheist",
+        "cost": "triple",
+        "description": "Roll a dice for each visible enemy fighter within 8\" of this fighter. On a roll of 5, allocate 1 damage point to the fighter being rolled for. On a roll of 6, allocate a number of damage points to the fighter being rolled for equal to the value of this ability.",
+        "runemarks": [
+            "terrifying"
+        ]
+    },
+    {
         "_id": "ad5ea812",
         "name": "Scent of Gore",
         "warband": "death",

--- a/python/data_parsing/fighters.py
+++ b/python/data_parsing/fighters.py
@@ -180,17 +180,21 @@ class Fighters:
 
         return max_values, min_values
 
-    def expected_damages(self) -> pd.DataFrame:
+    def expected_damages(
+            self,
+            vs_toughnesses: List[int] = range(3, 8), wounds: List[int] = None)-> pd.DataFrame:
         damage_index = list()
         expected_damages = dict()
-        for t in range(3, 8):
-            for w in [3, 4, 6, 8, 10, 12, 15, 20, 25]:
+        if not wounds:
+            wounds = [3, 4, 6, 8, 10, 12, 15, 20, 25]
+        for t in vs_toughnesses:
+            for w in wounds:
                 key = f'T{t}W{w}'
                 damage_index.append(key)
                 for f in self.fighters:
                     if f.name not in expected_damages.keys():
                         expected_damages[f.name] = list()
-                    ctk = f.dmg_chance(vs_t=t, vs_w=w)                # type: list[tuple[int, float]]
+                    ctk = f.dmg_chance(vs_t=t, dmg=w)                # type: List[Tuple[Tuple[int, str], float]]
                     ctk_percent = int(ctk[0][1] * 100)
                     expected_damages[f.name].append(ctk_percent)
 

--- a/python/utils.py
+++ b/python/utils.py
@@ -3,11 +3,9 @@ Utility functions and script for data manipulation and management
 """
 import json
 
-from data_parsing.fighters import Fighter, FighterJSONDataPayload
-from data_parsing.abilities import Ability, AbilityJSONDataPayload
-from data_parsing.models import DataPayload, DIST
-from data_parsing.warbands import WarbandsJSONDataPayload
-from pathlib import Path
+from data_parsing.fighters import Fighter
+from data_parsing.abilities import Ability
+from data_parsing.models import DataPayload
 from typing import List, Dict
 import uuid
 
@@ -49,18 +47,3 @@ def export_files(payloads: List[DataPayload]):
 
 def by_points(fighter: Fighter) -> int:
     return fighter.points
-
-
-if __name__ == '__main__':
-    # fighters = FighterJSONDataPayload()
-    # abilities = AbilityJSONDataPayload()
-
-    warbands = WarbandsJSONDataPayload()
-
-
-
-
-    # Do stuff with data, add it to new_data
-
-    # export_files([fighter_data_payload, ability_data_payload])
-


### PR DESCRIPTION
Chimera was all lowercase in abilities, has now been capitalised. Terrorgheist's Death Scream ability has had its warband fixed.
Also some code shuffling, moving __main__ out of utils for convenience.