### PR TITLE
runemark fix

### DIFF
--- a/data/Chaos/blades_of_khorne_bloodbound_abilities.json
+++ b/data/Chaos/blades_of_khorne_bloodbound_abilities.json
@@ -25,7 +25,8 @@
         "cost": "double",
         "description": "Pick a visible enemy fighter within 1\" of this fighter and roll 2 dice. For each roll of 4-5, allocate D3 damage points to that fighter. For each roll of 6, allocate D6 damage points to that fighter.",
         "runemarks": [
-            "ferocious"
+            "hero",
+            "champion"
         ]
     },
     {


### PR DESCRIPTION
> Hi, Happy Holidays (and I'm sure you guys aren't worried about making fixes to the website right now), but I just discovered that when I put the Mighty Lord of Khorne in my roster, the ability "Flesh Hound's Blood-dark Claws" doesn't appear in the abilities list.

Ability had the wrong runemarks (cross-ref against compendium)

https://discord.com/channels/1098769694611210240/1098769736290021537/1189067037704728576