### PR TITLE
FEC Update

### DIFF
--- a/data/Chaos/blades_of_khorne_bloodbound_abilities.json
+++ b/data/Chaos/blades_of_khorne_bloodbound_abilities.json
@@ -188,7 +188,7 @@
     },
     {
         "_id": "7491920a",
-        "name": "Would the Realm",
+        "name": "Wound the Realm",
         "warband": "Gorechosen of Dromm",
         "cost": "quad",
         "description": "Pick two visible battlefield corners or pick two visible objective tokens and draw a 1mm line between each. Roll a dice for each model touching that line. On a 3+, allocate a number of damage points equal to the value of this ability to that fighter.",

--- a/data/Chaos/chaos_abilities.json
+++ b/data/Chaos/chaos_abilities.json
@@ -358,6 +358,16 @@
         ]
     },
     {
+        "_id": "bb806355",
+        "name": "Cruel Strike",
+        "warband": "chaos",
+        "cost": "reaction",
+        "description": "A fighter can make this reaction when a visible enemy fighter within 1\" of them makes a disengage action but before that fighter moves away. Roll a dice. On a 2+, allocate D6 damage points to that enemy fighter.",
+        "runemarks": [
+            "icon-bearer"
+        ]
+    },
+    {
         "_id": "bf43048a",
         "name": "Marshal's Net",
         "warband": "chaos",

--- a/data/Chaos/disciples_of_tzeentch_daemons_abilities.json
+++ b/data/Chaos/disciples_of_tzeentch_daemons_abilities.json
@@ -101,7 +101,7 @@
         "name": "Sudden Warp-portal",
         "warband": "Ephilim's Pandaemonium",
         "cost": "double",
-        "description": "Pick another friendly fighter with the Ephilim’s Pandaemonium runemark within 12\" ofthis fighter. Make a note of that fighter’s location, then remove that fighter from the battlefield, and immediately set them up within 3\" of this fighter. Then remove this fighter from the battlefield, and set them up within 3\" of the other friendly fighter’s original location.",
+        "description": "Pick another friendly fighter with the Ephilim's Pandaemonium runemark within 12\" ofthis fighter. Make a note of that fighter's location, then remove that fighter from the battlefield, and immediately set them up within 3\" of this fighter. Then remove this fighter from the battlefield, and set them up within 3\" of the other friendly fighter's original location.",
         "runemarks": []
     },
     {
@@ -119,7 +119,7 @@
         "name": "Summoned Abomination",
         "warband": "Ephilim's Pandaemonium",
         "cost": "quad",
-        "description": "Pick a friendly fighter with the Ephilim’s Pandaemonium runemark that has been taken down. Set up that fighter on a platform or the battlefield floor, wholly within 3\" of this fighter. That fighter no longer counts as being taken down and has no damage points allocated to it.",
+        "description": "Pick a friendly fighter with the Ephilim's Pandaemonium runemark that has been taken down. Set up that fighter on a platform or the battlefield floor, wholly within 3\" of this fighter. That fighter no longer counts as being taken down and has no damage points allocated to it.",
         "runemarks": [
             "hero"
         ]

--- a/data/Death/flesh-eater_courts_abilities.json
+++ b/data/Death/flesh-eater_courts_abilities.json
@@ -1,51 +1,71 @@
 [
     {
-        "_id": "1223c872",
-        "name": "Chosen of the King",
+        "_id": "0d073880",
+        "name": "Baffling Parlay",
         "warband": "Flesh-eater Courts",
-        "cost": "double",
-        "description": "A fighter can use this abiltiy only if they are within 6\" of a visible friendly fighter with the Flesh-eater Courts faction runemark and both the Hero and Berserker runemarks. Until the end of this fighter's activation, add 2 to the Attacks characteristic of melee attack actions made by this fighter.",
-        "runemarks": [
-            "elite"
-        ]
-    },
-    {
-        "_id": "a35dcbba",
-        "name": "Feeding Frenzy",
-        "warband": "Flesh-eater Courts",
-        "cost": "double",
-        "description": "A fighter can only use this ability if an enemy fighter has been taken down by an attack action made by them this activation. Remove a number of damage points from this fighter up to the value of this ability.",
+        "cost": "reaction",
+        "description": "A fighter can make this reaction after they are targeted by a melee attack action but before the hit rolls are made.  Subtract 1 from the Attacks characteristic of that attack action, to a minimum of 1.",
         "runemarks": []
     },
     {
-        "_id": "c201a16b",
-        "name": "Skewering Strike",
+        "_id": "bec6b159",
+        "name": "Royal Bodyguard",
         "warband": "Flesh-eater Courts",
-        "cost": "double",
-        "description": "Add 1 to the Stregnth characteristic of the next melee attack action made by this fighter this activation. In addition, if that attack action scores a critical hit, until the end of the battle round, the target fighter cannot make move actions or disengage actions.",
+        "cost": "reaction",
+        "description": "A fighter can make this reaction when a friendly fighter with the Hero runemark within 3\" of them is targeted by an attack action, after the damage is totalled but before it is allocated, if it is enough for that fighter to be taken down. Allocate those damage points, one at a time, to this fighter instead. If this fighter is taken down, allocate any remaining damage points to that friendly Hero.",
         "runemarks": [
-            "agile"
+            "bulwark"
         ]
     },
     {
-        "_id": "84df9e3b",
-        "name": "Unnatural Vitality",
+        "_id": "79d9faa1",
+        "name": "Scrabbling Hordes",
         "warband": "Flesh-eater Courts",
         "cost": "double",
-        "description": "Remove a number of damage points from this fighter up to the value of this ability.",
+        "description": "Pick a visible friendly fighter within 6\" of this fighter that has the Flesh-eater Courts runemark and the Minion runemark that has not activated yet this battle round. You can activate that fighter immediately after this fighter's activation ends.",
+        "runemarks": [
+            "minion"
+        ]
+    },
+    {
+        "_id": "2e4501f8",
+        "name": "Hungry Talons",
+        "warband": "Flesh-eater Courts",
+        "cost": "double",
+        "description": "Until the end of the battle round, each time an enemy fighter within 6\" of this fighter makes a disengage action but before that fighter moves away, allocate D6 damage points to that fighter.",
+        "runemarks": []
+    },
+    {
+        "_id": "01e51087",
+        "name": "Winds of Shyish",
+        "warband": "Flesh-eater Courts",
+        "cost": "double",
+        "description": "A fighter can only use this ability if they are not within 3\" of any enemy fighters. Pick a visible friendly fighter that has a Wounds characteristic of 12 or less within 3\" of this fighter. Remove that fighter and this fighter from the battlefield and immediately set them up on the battlefield more than 5\" from all enemy fighters and wholly within 3\" of each other.",
         "runemarks": [
             "hero",
-            "berserker"
+            "trapper"
         ]
     },
     {
-        "_id": "9f8bae1a",
-        "name": "Bringer of Death",
+        "_id": "e986e07a",
+        "name": "Noble Winged Beast",
         "warband": "Flesh-eater Courts",
-        "cost": "triple",
-        "description": "Until the end of the battle round, add half the value of this ability (rounding up) to the Move characteristic of friendly fighters while they make a move action that starts within 6\" of this fighter.",
+        "cost": "double",
+        "description": "Until the end of this fighter's activation, do not count the vertical distance when measuring the range for attack actions made by this fighter.",
         "runemarks": [
-            "hero"
+            "hero",
+            "terrifying"
+        ]
+    },
+    {
+        "_id": "6e8e86a1",
+        "name": "Speak in Tongues",
+        "warband": "Flesh-eater Courts",
+        "cost": "double",
+        "description": "Pick an enemy fighter within 3\" of this fighter and roll a dice. On a 3+, that fighter makes 1 less action in their next activation (to a minimum of 1).",
+        "runemarks": [
+            "hero",
+            "priest"
         ]
     },
     {
@@ -53,20 +73,9 @@
         "name": "Death Scream",
         "warband": "Flesh-eater Courts",
         "cost": "triple",
-        "description": "Roll a dice for each visible enemy fighter within 8\" of this fighter. On a 5, allocate 1 damage point to the fighter being rolled for. On a 6, allocate a number of damage points to the fighter being rolled for equal to the value of this ability.",
+        "description": "Until the end of the battle round, enemy fighters within 6\" of this fighter cannot make reactions.",
         "runemarks": [
             "agile"
-        ]
-    },
-    {
-        "_id": "19b79e8e",
-        "name": "Stir of Black Hunger",
-        "warband": "Flesh-eater Courts",
-        "cost": "quad",
-        "description": "Until the end of the battle round, add 1 to the Attacks characteristic of melee attack actions made by visible friendly fighters while they are within 9\" of this fighter.",
-        "runemarks": [
-            "hero",
-            "berserker"
         ]
     },
     {
@@ -81,20 +90,53 @@
         ]
     },
     {
+        "_id": "98b3a5d8",
+        "name": "Predator's Pounce",
+        "warband": "Flesh-eater Courts",
+        "cost": "triple",
+        "description": "This fighter can make a bonus disengage action. Then this fighter can make a bonus move action.",
+        "runemarks": [
+            "mount"
+        ]
+    },
+    {
+        "_id": "183defcb",
+        "name": "King's Entreaty",
+        "warband": "Flesh-eater Courts",
+        "cost": "triple",
+        "description": "Pick a visible enemy fighter within 3\" of this fighter. That enemy fighter's player must accept or reject an infected bone. If they accept it, until the end of the battle, after that fighter's activation, roll a dice. On a 5+, that fighter is taken down. If they reject it, until the end of the battle, that fighter cannot use abilities.",
+        "runemarks": [
+            "hero",
+            "icon-bearer"
+        ]
+    },
+    {
+        "_id": "489f11f2",
+        "name": "Victory Feast",
+        "warband": "Flesh-eater Courts",
+        "cost": "triple",
+        "description": "A fighter can only use this ability if an enemy fighter has been taken down by an attack action made by them this activation. Remove a number of damage points allocated to each friendly fighter within 6\" of this fighter, up to half the value of this ability (rounding up). If this fighter has the Frenzied runemark, add 4 to the value of this ability, to a maximum of 7.",
+        "runemarks": [
+            "hero"
+        ]
+    },
+    {
         "_id": "ff7e8503",
         "name": "The Royal Hunt",
         "warband": "Flesh-eater Courts",
         "cost": "quad",
-        "description": "This fighter makes a bonus move action. Then, they can make a bonus attack action. In addition, add 1 to the Attacks characteristic of that attack action if this fighter is within 1\" of a visible friendly fighter.",
+        "description": "Add 1 to the Attacks and Damage characteristics of this fighter's melee weapons for each visible friendly fighter within 3\" of them until the end of their activation.",
         "runemarks": []
     },
     {
-        "_id": "0d073880",
-        "name": "Baffling Parlay",
+        "_id": "4d8af2ce",
+        "name": "Decree of Chivalry",
         "warband": "Flesh-eater Courts",
-        "cost": "reaction",
-        "description": "A fighter can make this reaction after they are targeted by a melee attack action but before the hit rolls are made.  Subtract 1 from the Attacks characteristic of that attack action, to a minimum of 1.",
-        "runemarks": []
+        "cost": "quad",
+        "description": "Until the end of the battle round, add 1 to the Attacks characteristic of melee attack actions made by visible friendly fighters while they are within 9\" of this fighter. If this fighter has the Berserker runemark, increase the range of this ability by a number of inches equal to the value of this ability.",
+        "runemarks": [
+            "hero"
+        ]
     },
     {
         "_id": "60f9e076",

--- a/data/Death/flesh-eater_courts_fighters.json
+++ b/data/Death/flesh-eater_courts_fighters.json
@@ -157,8 +157,7 @@
         "name": "Crypt Haunter",
         "points": 225,
         "runemarks": [
-            "hero",
-            "elite"
+            "hero"
         ],
         "toughness": 4,
         "warband": "Flesh-eater Courts",
@@ -307,32 +306,6 @@
         "wounds": 36
     },
     {
-        "_id": "be78aafb",
-        "bladeborn": "",
-        "grand_alliance": "death",
-        "movement": 5,
-        "name": "Abhorrant Cardinal",
-        "points": 130,
-        "runemarks": [
-            "hero",
-            "priest"
-        ],
-        "toughness": 4,
-        "warband": "Flesh-eater Courts",
-        "weapons": [
-            {
-                "attacks": 3,
-                "dmg_crit": 3,
-                "dmg_hit": 2,
-                "max_range": 1,
-                "min_range": 0,
-                "runemark": "claws",
-                "strength": 3
-            }
-        ],
-        "wounds": 18
-    },
-    {
         "_id": "6fdd0e19",
         "bladeborn": "",
         "grand_alliance": "death",
@@ -407,7 +380,7 @@
                 "dmg_hit": 2,
                 "max_range": 1,
                 "min_range": 0,
-                "runemark": "claws",
+                "runemark": "sword",
                 "strength": 3
             }
         ],
@@ -485,7 +458,7 @@
                 "dmg_hit": 4,
                 "max_range": 2,
                 "min_range": 0,
-                "runemark": "claws",
+                "runemark": "axe",
                 "strength": 5
             }
         ],

--- a/data/Death/flesh-eater_courts_fighters.json
+++ b/data/Death/flesh-eater_courts_fighters.json
@@ -5,8 +5,10 @@
         "grand_alliance": "death",
         "movement": 5,
         "name": "Crypt Ghoul",
-        "points": 55,
-        "runemarks": [],
+        "points": 60,
+        "runemarks": [
+            "minion"
+        ],
         "toughness": 3,
         "warband": "Flesh-eater Courts",
         "weapons": [
@@ -28,7 +30,7 @@
         "grand_alliance": "death",
         "movement": 5,
         "name": "Crypt Ghast",
-        "points": 105,
+        "points": 115,
         "runemarks": [
             "hero"
         ],
@@ -53,7 +55,7 @@
         "grand_alliance": "death",
         "movement": 5,
         "name": "Crypt Ghast Courtier",
-        "points": 135,
+        "points": 145,
         "runemarks": [
             "hero"
         ],
@@ -104,10 +106,8 @@
         "grand_alliance": "death",
         "movement": 6,
         "name": "Crypt Horror",
-        "points": 185,
-        "runemarks": [
-            "elite"
-        ],
+        "points": 180,
+        "runemarks": [],
         "toughness": 4,
         "warband": "Flesh-eater Courts",
         "weapons": [
@@ -207,10 +207,9 @@
         "grand_alliance": "death",
         "movement": 6,
         "name": "Crypt Haunter Courtier",
-        "points": 250,
+        "points": 255,
         "runemarks": [
-            "hero",
-            "elite"
+            "hero"
         ],
         "toughness": 4,
         "warband": "Flesh-eater Courts",
@@ -233,7 +232,7 @@
         "grand_alliance": "death",
         "movement": 10,
         "name": "Crypt Infernal",
-        "points": 275,
+        "points": 285,
         "runemarks": [
             "fly",
             "hero",
@@ -260,9 +259,8 @@
         "grand_alliance": "death",
         "movement": 8,
         "name": "Varghulf Courtier",
-        "points": 285,
+        "points": 300,
         "runemarks": [
-            "fly",
             "hero",
             "terrifying"
         ],
@@ -270,10 +268,10 @@
         "warband": "Flesh-eater Courts",
         "weapons": [
             {
-                "attacks": 3,
+                "attacks": 4,
                 "dmg_crit": 5,
                 "dmg_hit": 3,
-                "max_range": 2,
+                "max_range": 1,
                 "min_range": 0,
                 "runemark": "claws",
                 "strength": 5
@@ -287,7 +285,7 @@
         "grand_alliance": "death",
         "movement": 10,
         "name": "Crypt Infernal Courtier",
-        "points": 305,
+        "points": 315,
         "runemarks": [
             "fly",
             "hero",
@@ -307,6 +305,269 @@
             }
         ],
         "wounds": 36
+    },
+    {
+        "_id": "be78aafb",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 5,
+        "name": "Abhorrant Cardinal",
+        "points": 130,
+        "runemarks": [
+            "hero",
+            "priest"
+        ],
+        "toughness": 4,
+        "warband": "Flesh-eater Courts",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 3,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "claws",
+                "strength": 3
+            }
+        ],
+        "wounds": 18
+    },
+    {
+        "_id": "6fdd0e19",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 10,
+        "name": "Abhorrant Gorewarden",
+        "points": 225,
+        "runemarks": [
+            "hero",
+            "trapper",
+            "fly"
+        ],
+        "toughness": 3,
+        "warband": "Flesh-eater Courts",
+        "weapons": [
+            {
+                "attacks": 4,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "claws",
+                "strength": 4
+            }
+        ],
+        "wounds": 20
+    },
+    {
+        "_id": "f7e9b234",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 10,
+        "name": "Champion of Morbheg",
+        "points": 295,
+        "runemarks": [
+            "hero",
+            "mount",
+            "fly"
+        ],
+        "toughness": 5,
+        "warband": "Flesh-eater Courts",
+        "weapons": [
+            {
+                "attacks": 4,
+                "dmg_crit": 4,
+                "dmg_hit": 3,
+                "max_range": 2,
+                "min_range": 0,
+                "runemark": "spear",
+                "strength": 4
+            }
+        ],
+        "wounds": 25
+    },
+    {
+        "_id": "48828f14",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 5,
+        "name": "Crypt Captain with Cursed Blade",
+        "points": 135,
+        "runemarks": [
+            "hero",
+            "bulwark",
+            "minion"
+        ],
+        "toughness": 4,
+        "warband": "Flesh-eater Courts",
+        "weapons": [
+            {
+                "attacks": 4,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "claws",
+                "strength": 3
+            }
+        ],
+        "wounds": 10
+    },
+    {
+        "_id": "8de8ea05",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 5,
+        "name": "Crypt Captain with Cursed Halberd",
+        "points": 140,
+        "runemarks": [
+            "hero",
+            "bulwark",
+            "minion"
+        ],
+        "toughness": 4,
+        "warband": "Flesh-eater Courts",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 2,
+                "min_range": 0,
+                "runemark": "spear",
+                "strength": 4
+            }
+        ],
+        "wounds": 10
+    },
+    {
+        "_id": "d90931c1",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 5,
+        "name": "Marrowscroll Herald",
+        "points": 155,
+        "runemarks": [
+            "hero",
+            "icon-bearer"
+        ],
+        "toughness": 4,
+        "warband": "Flesh-eater Courts",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 4,
+                "dmg_hit": 2,
+                "max_range": 2,
+                "min_range": 0,
+                "runemark": "claws",
+                "strength": 4
+            }
+        ],
+        "wounds": 18
+    },
+    {
+        "_id": "109ef3fa",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 5,
+        "name": "Royal Decapitator",
+        "points": 175,
+        "runemarks": [
+            "hero"
+        ],
+        "toughness": 4,
+        "warband": "Flesh-eater Courts",
+        "weapons": [
+            {
+                "attacks": 2,
+                "dmg_crit": 5,
+                "dmg_hit": 4,
+                "max_range": 2,
+                "min_range": 0,
+                "runemark": "claws",
+                "strength": 5
+            }
+        ],
+        "wounds": 18
+    },
+    {
+        "_id": "9305b756",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 5,
+        "name": "Cryptguard with Cursed Blade",
+        "points": 80,
+        "runemarks": [
+            "bulwark",
+            "minion"
+        ],
+        "toughness": 4,
+        "warband": "Flesh-eater Courts",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 3,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "sword",
+                "strength": 3
+            }
+        ],
+        "wounds": 10
+    },
+    {
+        "_id": "f1999f34",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 5,
+        "name": "Cryptguard with Cursed Halberd",
+        "points": 85,
+        "runemarks": [
+            "bulwark",
+            "minion"
+        ],
+        "toughness": 4,
+        "warband": "Flesh-eater Courts",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 3,
+                "dmg_hit": 2,
+                "max_range": 2,
+                "min_range": 0,
+                "runemark": "spear",
+                "strength": 3
+            }
+        ],
+        "wounds": 10
+    },
+    {
+        "_id": "169ae3b2",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 10,
+        "name": "Morbheg Knights",
+        "points": 220,
+        "runemarks": [
+            "mount",
+            "fly"
+        ],
+        "toughness": 5,
+        "warband": "Flesh-eater Courts",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 4,
+                "dmg_hit": 3,
+                "max_range": 2,
+                "min_range": 0,
+                "runemark": "spear",
+                "strength": 4
+            }
+        ],
+        "wounds": 20
     },
     {
         "_id": "4e96345e",

--- a/data/Death/flesh-eater_courts_fighters.json
+++ b/data/Death/flesh-eater_courts_fighters.json
@@ -81,7 +81,7 @@
         "points": 165,
         "runemarks": [
             "hero",
-            "berserker"
+            "frenzied"
         ],
         "toughness": 4,
         "warband": "Flesh-eater Courts",
@@ -483,5 +483,31 @@
             }
         ],
         "wounds": 20
+    },
+    {
+        "_id": "0dcac829",
+        "bladeborn": "",
+        "grand_alliance": "death",
+        "movement": 5,
+        "name": "Abhorrant Cardinal",
+        "points": 130,
+        "runemarks": [
+            "hero",
+            "priest"
+        ],
+        "toughness": 4,
+        "warband": "Flesh-eater Courts",
+        "weapons": [
+            {
+                "attacks": 3,
+                "dmg_crit": 3,
+                "dmg_hit": 2,
+                "max_range": 1,
+                "min_range": 0,
+                "runemark": "claws",
+                "strength": 3
+            }
+        ],
+        "wounds": 18
     }
 ]

--- a/data/Death/nighthaunt_abilities.json
+++ b/data/Death/nighthaunt_abilities.json
@@ -143,7 +143,7 @@
         "name": "Swift Judgement",
         "warband": "The Headsmen's Curse",
         "cost": "double",
-        "description": "This fighter makes a bonus move action of up to a number of 3 inches equal to the value of this ability and must finish closer to the closest visible enemy fighter than they were at the start of that move action.",
+        "description": "This fighter makes a bonus move action of up to a number of inches equal to the value of this ability and must finish closer to the closest visible enemy fighter than they were at the start of that move action.",
         "runemarks": []
     },
     {

--- a/data/Death/nighthaunt_abilities.json
+++ b/data/Death/nighthaunt_abilities.json
@@ -151,7 +151,7 @@
         "name": "Sharpen",
         "warband": "The Headsmen's Curse",
         "cost": "double",
-        "description": "Pick a friendly fighter with the Hero runemark and The Headsmen’s Curse runemark within 3\" of this fighter. Add 2 to the damage points allocated to enemy fighters by each critical hit from the next melee attack action made by that fighter.",
+        "description": "Pick a friendly fighter with the Hero runemark and The Headsmen's Curse runemark within 3\" of this fighter. Add 2 to the damage points allocated to enemy fighters by each critical hit from the next melee attack action made by that fighter.",
         "runemarks": [
             "agile"
         ]
@@ -161,7 +161,7 @@
         "name": "Hold Them Still",
         "warband": "The Headsmen's Curse",
         "cost": "triple",
-        "description": "Pick an enemy fighter within 1\" of this fighter. That fighter cannot make disengage actions until the end of the battle round. In addition, subtract the value of this ability from that fighter’s Move characteristic until the end of the battle round (to a minimum of 0).",
+        "description": "Pick an enemy fighter within 1\" of this fighter. That fighter cannot make disengage actions until the end of the battle round. In addition, subtract the value of this ability from that fighter's Move characteristic until the end of the battle round (to a minimum of 0).",
         "runemarks": []
     },
     {
@@ -169,7 +169,7 @@
         "name": "The Court Sentences You... To Death!",
         "warband": "The Headsmen's Curse",
         "cost": "quad",
-        "description": "This fighter makes a bonus move action. Add x to the Attacks  characteristic of the next melee attack action made by this fighter in this activation and add x to the damage points allocated to enemy fighters by each critical hit from that attack action, where x is the number of friendly fighters with The Headsmen’s Curse runemark within 3\" of the target.",
+        "description": "This fighter makes a bonus move action. Add x to the Attacks  characteristic of the next melee attack action made by this fighter in this activation and add x to the damage points allocated to enemy fighters by each critical hit from that attack action, where x is the number of friendly fighters with The Headsmen's Curse runemark within 3\" of the target.",
         "runemarks": [
             "hero"
         ]

--- a/data/Order/cities_of_sigmar_castelite_hosts_abilities.json
+++ b/data/Order/cities_of_sigmar_castelite_hosts_abilities.json
@@ -76,7 +76,6 @@
         "cost": "triple",
         "description": "Roll a number of dice equal to the number of friendly fighters with the Cities of Sigmar: Castelite Hosts faction runemark that have been taken down and/ or have 1 or more damage points allocated to them. For each roll of 4+, add one wild dice to your saved wild dice.",
         "runemarks": [
-            "hero",
             "priest"
         ]
     },


### PR DESCRIPTION
Updates Flesh-eater Courts for their 31/1/24 changes - https://www.warhammer-community.com/2024/01/31/the-flesh-eater-courts-march-on-the-gnarlwood-with-free-rules-for-warcry/

Includes other fixes from Warcrier feedback.