### PR TITLE
Support for Battletraits

### DIFF
--- a/data/Chaos/beasts_of_chaos_abilities.json
+++ b/data/Chaos/beasts_of_chaos_abilities.json
@@ -109,6 +109,14 @@
         "runemarks": []
     },
     {
+        "_id": "3647d6ce",
+        "name": "Beastman Ambush",
+        "warband": "Beasts of Chaos",
+        "cost": "battletrait",
+        "description": "After deployment, you can pick a friendly fighter from each battle group that is on the battlefield. Remove those fighters from the battlefield. At the start of battle rounds 2, 3, and 4, you can place one of those fighters on the battlefield, more than 6\" from each enemy fighter and wholly within 3\" of one or more battlefield edges.",
+        "runemarks": []
+    },
+    {
         "_id": "fbce3d1d",
         "name": "Savage Bolt",
         "warband": "Grashrak's Despoilers",

--- a/data/Chaos/blades_of_khorne_bloodbound_abilities.json
+++ b/data/Chaos/blades_of_khorne_bloodbound_abilities.json
@@ -131,6 +131,14 @@
         "runemarks": []
     },
     {
+        "_id": "8ddef5ee",
+        "name": "No Respite",
+        "warband": "Blades of Khorne: Bloodbound",
+        "cost": "battletrait",
+        "description": "When a friendly fighter with this battle trait is taken down, before they are removed from play, pick a visible enemy fighter within 1\" of them and roll a dice. On a 4+, allocate D3 damage points to that fighter.",
+        "runemarks": []
+    },
+    {
         "_id": "a659404f",
         "name": "Decapitating Strike",
         "warband": "Garrek's Reavers",

--- a/data/Chaos/blades_of_khorne_daemons_abilities.json
+++ b/data/Chaos/blades_of_khorne_daemons_abilities.json
@@ -64,5 +64,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction after they are targeted by a melee attack action but before the hit rolls are made. For each hit roll from that attack action that misses, allocate 2 damage points to the attacking fighter. For each critical hit from that attack action, allocate 1 additional damage point to this fighter.",
         "runemarks": []
+    },
+    {
+        "_id": "7ea9a3b3",
+        "name": "Blood Calls to Blood",
+        "warband": "Blades of Khorne: Daemons",
+        "cost": "battletrait",
+        "description": "If there are one or more friendly fighters with this battle trait on the battlefield, at the end of each battle round, you can pick an enemy fighter with one or more damage points allocated to them. Roll 2D6. On a roll of 8+, allocate 3 damage points to that fighter.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/chaos_abilities.json
+++ b/data/Chaos/chaos_abilities.json
@@ -449,5 +449,13 @@
         "runemarks": [
             "mystic"
         ]
+    },
+    {
+        "_id": "534a3cce",
+        "name": "Aspire to Glory",
+        "warband": "chaos",
+        "cost": "battletrait",
+        "description": "Once per battle round, add 1 to the damage points allocated by the first critical hit from a melee attack action made by any friendly fighter with this battle trait that has a points cost of 125 or less.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/chaos_legionnaires_abilities.json
+++ b/data/Chaos/chaos_legionnaires_abilities.json
@@ -64,5 +64,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction when an enemy fighter ends their move action visible to this fighter and within 3\" of this fighter.  Pick another friendly fighter within 3\" of this fighter.  That fighter makes a bonus move action.  After that move action that fighter must be within 1\" of the enemy fighter that made the move action.",
         "runemarks": []
+    },
+    {
+        "_id": "e59b9ad0",
+        "name": "Master Manipulators",
+        "warband": "Chaos Legionnaires",
+        "cost": "battletrait",
+        "description": "When determining who has the initiative, but not when seizing the initiative, if there is a tie, do not roll off. Instead the player of this warband chooses which tied player has the initiative. If multiple warbands have this battle trait, the players of those warbands roll off, and the winner chooses which tied player has the initiative.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/claws_of_karanak_abilities.json
+++ b/data/Chaos/claws_of_karanak_abilities.json
@@ -62,5 +62,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction after a visible enemy fighter within 1\" of them makes a disengage action.  Until the end of the battle round, add 1 to the Attacks characteristic of melee attack actions made by friendly fighters that target that enemy fighter.",
         "runemarks": []
+    },
+    {
+        "_id": "01dc1cd0",
+        "name": "No Claw Unbloodied",
+        "warband": "Claws of Karanak",
+        "cost": "battletrait",
+        "description": "Each time an enemy fighters makes a disengage action, roll a dice. On a roll of 2+, allocate 1 damage point to that enemy fighter for each friendly fighter with this battle trait within 1\" of that enemy fighter.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/corvus_cabal_abilities.json
+++ b/data/Chaos/corvus_cabal_abilities.json
@@ -78,5 +78,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction after an enemy fighter finishes a move action visible to this fighter, within 5\" horizontally and vertically lower than this fighter. This fighter makes a bonus move action and must finish closer to that enemy fighter than they were at the start of that move action. If this fighter ends that move within 1\" of that enemy fighter, this fighter does not suffer impact damage and that enemy fighter suffers impact damage.",
         "runemarks": []
+    },
+    {
+        "_id": "f90c6d85",
+        "name": "Plunging Killers",
+        "warband": "Corvus Cabal",
+        "cost": "battletrait",
+        "description": "Add 2 of the Strength characteristics of melee attack actions made by friendly fighters with this battle trait if they fell this activation.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/cypher_lords_abilities.json
+++ b/data/Chaos/cypher_lords_abilities.json
@@ -60,5 +60,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction after an enemy fighter finishes a move action visible to this fighter and within 3\" of this fighter. Pick another friendly fighter with the Cypher Lords faction runemark and the Mystic runemark. That fighter makes a bonus move action. After that move action that fighter must be within 1\" of the enemy fighter that made the move action.",
         "runemarks": []
+    },
+    {
+        "_id": "8a373d09",
+        "name": "Matchless Acrobats",
+        "warband": "Cypher Lords",
+        "cost": "battletrait",
+        "description": "After a friendly fighter with this battle trait uses an ability, roll a dice. On a 5+, add one wild dice to your saved wild dice.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/darkoath_savagers_abilities.json
+++ b/data/Chaos/darkoath_savagers_abilities.json
@@ -62,5 +62,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction after they are targeted by an attack action, after the hit rolls have been made. Roll a dice for each critical hit. On a roll of 4+, that critical hit becomes a hit instead.",
         "runemarks": []
+    },
+    {
+        "_id": "dd042d72",
+        "name": "Seeking Glory",
+        "warband": "Darkoath Savagers",
+        "cost": "battletrait",
+        "description": "After an enemy leader has been taken down by a melee attack action made by a friendly fighter with this battle trait, add two wild dice to your saved wild dice.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/disciples_of_tzeentch_arcanites_abilities.json
+++ b/data/Chaos/disciples_of_tzeentch_arcanites_abilities.json
@@ -109,6 +109,14 @@
         "runemarks": []
     },
     {
+        "_id": "a98cd193",
+        "name": "Warp Fate",
+        "warband": "Disciples of Tzeentch: Arcanites",
+        "cost": "battletrait",
+        "description": "After the initiative phase, starting with the attacker, each player of a warband with this battle trait can roll one dice for each [double], [triple], or [quad] they have. On a 4+, change the value of those ability dice to 6.",
+        "runemarks": []
+    },
+    {
         "_id": "9a8df7e9",
         "name": "Split Into Brimstone Horrors",
         "warband": "Eyes of the Nine",

--- a/data/Chaos/disciples_of_tzeentch_daemons_abilities.json
+++ b/data/Chaos/disciples_of_tzeentch_daemons_abilities.json
@@ -87,6 +87,14 @@
         ]
     },
     {
+        "_id": "d405bcb7",
+        "name": "Warp Destiny",
+        "warband": "Disciples of Tzeentch: Daemons",
+        "cost": "battletrait",
+        "description": "After the initiative phase, each player whose warband has this battle trait can pick two any [double], [triple] or [quad] they have. Swap the values of those ability dice.",
+        "runemarks": []
+    },
+    {
         "_id": "1adaca07",
         "name": "Hypnotise",
         "warband": "Ephilim's Pandaemonium",

--- a/data/Chaos/hedonites_of_slaanesh_daemons_abilities.json
+++ b/data/Chaos/hedonites_of_slaanesh_daemons_abilities.json
@@ -88,6 +88,14 @@
         "runemarks": []
     },
     {
+        "_id": "77b23b24",
+        "name": "Lure of the Missing God",
+        "warband": "Hedonites of Slaanesh: Daemons",
+        "cost": "battletrait",
+        "description": "After the initiative phase,  you can pick an enemy fighter within 1\" of one of more friendly fighters with this battle trait and then roll a dice. On a roll of 3+, until the end of the battle round, that fighter cannot make disengage actions.",
+        "runemarks": []
+    },
+    {
         "_id": "43a7aafc",
         "name": "Triumphant Tittering",
         "warband": "Thricefold Discord",

--- a/data/Chaos/hedonites_of_slaanesh_sybarites_abilities.json
+++ b/data/Chaos/hedonites_of_slaanesh_sybarites_abilities.json
@@ -108,6 +108,14 @@
         ]
     },
     {
+        "_id": "4d682138",
+        "name": "Pain-fuelled Rapture",
+        "warband": "Hedonites of Slaanesh: Sybarites",
+        "cost": "battletrait",
+        "description": "After a friendly fighter with this  battle trait is allocated one or more damage points by an attack action or reaction, you can choose for that fighter to enter a pain-fuelled rapture. If they do so, allocate 3 damage points to that friendly fighter, and then add 2 to the Attacks characteristic of the next attack action made by this fighter in this battle round.",
+        "runemarks": []
+    },
+    {
         "_id": "60eaf064",
         "name": "Cavalcade of Madness",
         "warband": "The Dread Pageant",

--- a/data/Chaos/horns_of_hashut_abilities.json
+++ b/data/Chaos/horns_of_hashut_abilities.json
@@ -66,5 +66,13 @@
         "runemarks": [
             "warrior"
         ]
+    },
+    {
+        "_id": "e6860f13",
+        "name": "A Realm of Fire and Ash",
+        "warband": "Horns of Hashut",
+        "cost": "battletrait",
+        "description": "If one or more friendly fighters with this battle trait are on the battlefield, each time an enemy fighter suffers impact damage, subtract 2 from the dice roll, to a minimum of 1.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/iron_golems_abilities.json
+++ b/data/Chaos/iron_golems_abilities.json
@@ -64,5 +64,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction after they are targeted by a melee attack action but before the hit rolls are made. Count up to two critical hits from that attack action as hits instead.",
         "runemarks": []
+    },
+    {
+        "_id": "cc1d2c0a",
+        "name": "We Make War",
+        "warband": "Iron Golems",
+        "cost": "battletrait",
+        "description": "After the initiative phase, starting with the attacker, each player whose warband has this battle trait can pick a [double], [triple], or [quad] they have. Change the value of those ability dice to 6.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/jade_obelisk_abilities.json
+++ b/data/Chaos/jade_obelisk_abilities.json
@@ -64,5 +64,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction when they are targeted by a melee attack action but before the hit rolls are made.  Subtract 1 from the damage points allocated to this fighter by each hit and critical hit from that attack action (to a minimum of 1).",
         "runemarks": []
+    },
+    {
+        "_id": "8d77431d",
+        "name": "Blessings of the Speaker",
+        "warband": "Jade Obelisk",
+        "cost": "battletrait",
+        "description": "The first time this battle that a friendly fighter with this battle trait uses the 'Bloody Tribute' ability, you can remove each damage point allocated to one friendly fighter with the Icon Bearer runemark.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/maggotkin_of_nurgle_daemons_abilities.json
+++ b/data/Chaos/maggotkin_of_nurgle_daemons_abilities.json
@@ -97,5 +97,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction when they are targeted by a melee attack action but before the hit rolls are made. Subtract 1 from the damage points allocated to this fighter by each hit from that attack action (to a minimum of 1).",
         "runemarks": []
+    },
+    {
+        "_id": "a2de23f6",
+        "name": "Infection Vectors",
+        "warband": "Maggotkin of Nurgle: Daemons",
+        "cost": "battletrait",
+        "description": "At the start of each battle round, roll a dice for each enemy fighter within 1\" of one or more friendly fighters. On a roll of 5+, allocate 1 damage point to that fighter. Enemy fighters with this battle trait or the 'Disease-ridden' battle trait cannot be affected.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/maggotkin_of_nurgle_rotbringers_abilities.json
+++ b/data/Chaos/maggotkin_of_nurgle_rotbringers_abilities.json
@@ -107,6 +107,14 @@
         ]
     },
     {
+        "_id": "7321b833",
+        "name": "Disease-ridden",
+        "warband": "Maggotkin of Nurgle: Rotbringers",
+        "cost": "battletrait",
+        "description": "At the start of each battle round, you can pick one enemy fighter within 1\" of one or more friendly fighters and roll a dice. On a 5+, that fighter cannot use abilities or reactions this battle round. Enemy fighters with this battle trait or the 'Infection Vectors' battle trait cannot be affected.",
+        "runemarks": []
+    },
+    {
         "_id": "99104002",
         "name": "Draw Upon the Retchling's Power",
         "warband": "The Wurmspat",

--- a/data/Chaos/rotmire_creed_abilities.json
+++ b/data/Chaos/rotmire_creed_abilities.json
@@ -64,5 +64,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction when they are targeted by a melee attack action.  After the damage is totalled but before it is allocated to this fighter, roll a dice for each critical hit scored from that attack action.  For each 3+, allocate 3 damage points to the fighter that made that attack action.",
         "runemarks": []
+    },
+    {
+        "_id": "4a01b3c0",
+        "name": "Waiting for the Lord Leech",
+        "warband": "Rotmire Creed",
+        "cost": "battletrait",
+        "description": "Enemy fighters that are within 1\" of two or more friendly fighters with this battle trait cannot make disengage actions.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/scions_of_the_flame_abilities.json
+++ b/data/Chaos/scions_of_the_flame_abilities.json
@@ -64,5 +64,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction after they are targeted by a melee attack action but before the hit rolls are made. For each hit roll from that attack action that hits, allocate 1 damage point to the attacking fighter. For each critical hit, allocate 2 damage points to the attacking fighter instead.",
         "runemarks": []
+    },
+    {
+        "_id": "5e51980a",
+        "name": "Seared Wounds",
+        "warband": "Scions of the Flame",
+        "cost": "battletrait",
+        "description": "Each time 1 or more damage points allocated to an enemy fighter would be removed, subtract 1 from the total to be removed, to a minimum of 0.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/skaven_abilities.json
+++ b/data/Chaos/skaven_abilities.json
@@ -171,6 +171,14 @@
         "runemarks": []
     },
     {
+        "_id": "742d4be3",
+        "name": "There are Always More",
+        "warband": "Skaven",
+        "cost": "battletrait",
+        "description": "At the end of the battle rounds 2 and 3, you can pick a friendly fighter with this battle trait that is taken down and has a points cost of 70 or less. At the start of the next battle round, you can place that fighter on a platform or on the battlefield floor, more than 6\" from each enemy fighter, objective and treasure token, and within 3\" of one or more battlefield edges.",
+        "runemarks": []
+    },
+    {
         "_id": "755687fc",
         "name": "Way of the Slinking Rat",
         "warband": "Skittershank's Clawpack",

--- a/data/Chaos/slaves_to_darkness_abilities.json
+++ b/data/Chaos/slaves_to_darkness_abilities.json
@@ -209,5 +209,13 @@
         "runemarks": [
             "ferocious"
         ]
+    },
+    {
+        "_id": "6b9e1c30",
+        "name": "For the Glory of the Dark Gods",
+        "warband": "Slaves to Darkness",
+        "cost": "battletrait",
+        "description": "While more enemy fighters are taken down than friendly fighters with this battle trait are taken down, add 3 to the value of your ability dice, to a maximum of 6. ",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/spire_tyrants_abilities.json
+++ b/data/Chaos/spire_tyrants_abilities.json
@@ -64,5 +64,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction after they are targeted by a melee attack action but before the hit rolls are made. If none of the hit rolls from that attack action result in a critical hit, allocate 4 damage points to the attacking fighter.",
         "runemarks": []
+    },
+    {
+        "_id": "3636986f",
+        "name": "Entertain Me!",
+        "warband": "Spire Tyrants",
+        "cost": "battletrait",
+        "description": "Once per battle round, a friendly fighter with this battle trait within 1\" of one or more enemy fighters can pick one of those enemy fighter to duel. When they do so, each time that friendly fighter makes an attack action that targets that enemy fighter, you can change the Strength characteristic of that attack action to equal the Toughness characteristic of that enemy fighter. ",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/splintered_fang_abilities.json
+++ b/data/Chaos/splintered_fang_abilities.json
@@ -62,5 +62,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction after they are targeted by a melee attack action but before the hit rolls are made. For each hit roll of 1 or 2 from that attack action, allocate 2 damage points to the attacking fighter.",
         "runemarks": []
+    },
+    {
+        "_id": "e7ec1fba",
+        "name": "Weapons Dripping with Poison",
+        "warband": "Splintered Fang",
+        "cost": "battletrait",
+        "description": "Once per battle round, a friendly fighter with this battle trait can use the 'Poisoned Attacks' ability without needing or spending any ability dice. Tread the value of that ability as 6.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/tarantulos_brood_abilities.json
+++ b/data/Chaos/tarantulos_brood_abilities.json
@@ -66,5 +66,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction after they are targeted by a melee attack action but before the hit rolls are made. For each hit roll of 1 or 2 from that attack action, allocate 2 damage points to the attacking fighter.",
         "runemarks": []
+    },
+    {
+        "_id": "0a89a316",
+        "name": "Eightfold Allies",
+        "warband": "Tarantulos Brood",
+        "cost": "battletrait",
+        "description": "Once per battle, a friendly fighter with this battle trait can use the 'Creeping Summons' ability without needing or spending any ability dice, and can use that ability as if they had the Hero runemark.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/the_unmade_abilities.json
+++ b/data/Chaos/the_unmade_abilities.json
@@ -60,5 +60,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction after they are targeted by a melee attack action but before the hit rolls are made. For each hit roll from that attack action that hits, allocate 1 damage point to the attacking fighter. For each critical hit, allocate 2 damage points to the attacking fighter instead.",
         "runemarks": []
+    },
+    {
+        "_id": "d208fe19",
+        "name": "Shared Bliss",
+        "warband": "The Unmade",
+        "cost": "battletrait",
+        "description": "Once per battle, after an enemy fighter is taken down by the damage points allocated by the 'Shared Pain' reaction, roll a dice. On 1 3+, you gain a [quad] ability dice with a value of 1.",
+        "runemarks": []
     }
 ]

--- a/data/Chaos/untamed_beasts_abilities.json
+++ b/data/Chaos/untamed_beasts_abilities.json
@@ -62,5 +62,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction when they are targeted by a melee attack action but before the hit rolls are made. Subtract 1 from the damage points allocated to this fighter by each hit from that attack action (to a minimum of 1).",
         "runemarks": []
+    },
+    {
+        "_id": "7ead189d",
+        "name": "Worthy Prey",
+        "warband": "Untamed Beasts",
+        "cost": "battletrait",
+        "description": "At the start of each battle round, if no enemy fighters are your worthy prey, pick an enemy fighter. That fighter is your worth prey. While that fighter is your worthy prey, abilities that target that fighter are treated as having a value of 6.",
+        "runemarks": []
     }
 ]

--- a/data/Death/askurgan_trueblades_abilities.json
+++ b/data/Death/askurgan_trueblades_abilities.json
@@ -64,5 +64,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction when they are targeted by a melee attack action but before the hit rolls are made.  Add 1 to this fighter's Toughness characteristic during that attack action.",
         "runemarks": []
+    },
+    {
+        "_id": "344f399f",
+        "name": "Worthy Draught",
+        "warband": "Askurgan Trueblades",
+        "cost": "battletrait",
+        "description": "After an enemy fighter with the Hero runemark and/or that has a Wounds characteristic of 30 or greater has been taken down by a melee attack action made by a friendly fighter with this battle trait, remove D6 damage points allocated to that friendly fighter.",
+        "runemarks": []
     }
 ]

--- a/data/Death/death_abilities.json
+++ b/data/Death/death_abilities.json
@@ -94,5 +94,13 @@
         "runemarks": [
             "thrall"
         ]
+    },
+    {
+        "_id": "6321786c",
+        "name": "Deathless Minions",
+        "warband": "death",
+        "cost": "battletrait",
+        "description": "Once per battle round, count the first critical hit from a ranged attack action that targets a friendly fighter with this battle trait that has the Minion runemark as a hit instead.",
+        "runemarks": []
     }
 ]

--- a/data/Death/flesh-eater_courts_abilities.json
+++ b/data/Death/flesh-eater_courts_abilities.json
@@ -128,14 +128,12 @@
         ]
     },
     {
-        "_id": "60f9e076",
-        "name": "Royal Decree",
-        "warband": "The Grymwatch",
-        "cost": "double",
-        "description": "Pick a visible friendly fighter with both The Grymwatch runemark and the Minion runemark within 3\" of this fighter. That fighter can make a bonus attack action.",
-        "runemarks": [
-            "hero"
-        ]
+        "_id": "c041c79a",
+        "name": "Form a Lance",
+        "warband": "Flesh-eater Courts",
+        "cost": "battletrait",
+        "description": "Add 1 to the Move characteristics of friendly fighters with this battle trait that were within 1\" of two or more other friendly fighters with this battle trait at the start of their activation. Add 1 to the Strength characteristic of melee attack actions made by friendly fighters with this battle trait while they are within 1\" of two or more other friendly fighters with this battle trait.",
+        "runemarks": []
     },
     {
         "_id": "c4d22bf7",
@@ -168,5 +166,15 @@
         "cost": "quad",
         "description": "The next melee attack action made by this fighter scores critical hits on a 3+ regardless of the Toughness characteristic of the target.",
         "runemarks": []
+    },
+    {
+        "_id": "60f9e076",
+        "name": "Royal Decree",
+        "warband": "The Grymwatch",
+        "cost": "double",
+        "description": "Pick a visible friendly fighter with both The Grymwatch runemark and the Minion runemark within 3\" of this fighter. That fighter can make a bonus attack action.",
+        "runemarks": [
+            "hero"
+        ]
     }
 ]

--- a/data/Death/nighthaunt_abilities.json
+++ b/data/Death/nighthaunt_abilities.json
@@ -137,6 +137,14 @@
         "runemarks": []
     },
     {
+        "_id": "c20df7c5",
+        "name": "Wave of Terror",
+        "warband": "Nighthaunt",
+        "cost": "battletrait",
+        "description": "Add 1 to the Strength characteristics of melee attack actions made by friendly fighters with this battle trait if they made a move action this activation.",
+        "runemarks": []
+    },
+    {
         "_id": "120b6102",
         "name": "Swift Judgement",
         "warband": "The Headsmen's Curse",

--- a/data/Death/ossiarch_bonereapers_abilities.json
+++ b/data/Death/ossiarch_bonereapers_abilities.json
@@ -138,5 +138,13 @@
         "runemarks": [
             "elite"
         ]
+    },
+    {
+        "_id": "2eddaae2",
+        "name": "Ranks Unbroken By Dissent",
+        "warband": "Ossiarch Bonereapers",
+        "cost": "battletrait",
+        "description": "If a friendly fighter with this battle trait uses an ability that requires the Ossirach Bonereapers runemark and has a range, add 1\" to the range of the ability.",
+        "runemarks": []
     }
 ]

--- a/data/Death/pyregheists_abilities.json
+++ b/data/Death/pyregheists_abilities.json
@@ -1,64 +1,72 @@
 [
-  {
-    "_id": "22050b34",
-    "name": "Balefire Cremation",
-    "warband": "Pyregheists",
-    "cost": "passive",
-    "description": "When an ability tells you to cremate a fighter, remove that fighter from the battlefield and place a Pyre token at the centre of the space occupied by that fighter. At the end of the battle round, after determining control of objectives, allocate 3 damage to each enemy fighter within 1\" of the centre of one or more Pyre tokens.",
-    "runemarks": []
-  },
-
-  {
-    "_id": "78f7d995",
-    "name": "Fan the Flames",
-    "warband": "Pyregheists",
-    "cost": "double",
-    "description": "Add 1 to the damage points allocated by each hit and each critical hit from the next melee attack action made by this fighter this activation.",
-    "runemarks": []
-  },
-
-  {
-    "_id": "20a38f4f",
-    "name": "Pyrerobber's Curse",
-    "warband": "Pyregheists",
-    "cost": "double",
-    "description": "Until the end of this fighter's activation, add 1 to the Strength characteristic of attack actions made by this fighter. Until the end of this fighter's activation, when their attack action takes down an enemy fighter, cremate that enemy fighter.",
-    "runemarks": ["frenzied"]
-  },
-
-  {
-    "_id": "779e2be9",
-    "name": "Unblinking Guardian",
-    "warband": "Pyregheists",
-    "cost": "double",
-    "description": "Until the end of the battle round, add 1 to the Toughness characteristic of friendly fighters with the Elite or Hero runemarks while they are within 3\" of this fighter.",
-    "runemarks": ["elite"]
-  },
-
-  {
-    "_id": "85b75c37",
-    "name": "Light the Pyre",
-    "warband": "Pyregheists",
-    "cost": "triple",
-    "description": "A fighter can only use this ability when their attack action takes down an enemy fighter. Cremate that enemy fighter.",
-    "runemarks": []
-  },
-
-  {
-    "_id": "6bb4417d",
-    "name": "Soulblaze",
-    "warband": "Pyregheists",
-    "cost": "triple",
-    "description": "A fighter can only use this ability if an enemy fighter has been taken down this battle round. Pick a number of visible friendly fighters with the Pyregheists runemark equal to half the value of this ability (rounding up). Each fighter you picked can make a bonus move action or a bonus attack action (some can make a bonus move action and others can make a bonus attack action).",
-    "runemarks": ["hero"]
-  },
-
-  {
-    "_id": "ad5d0eb1",
-    "name": "Agonising Penance",
-    "warband": "Pyregheists",
-    "cost": "quad",
-    "description": "Pick a visible enemy fighter within 6\" of this fighter. That enemy fighter makes a bonus move action directly towards the closest other fighter from their warband, as if they were jumping, a number of inches equal to the value of this ability. When doing so, they can move away from enemy fighters within 1\" at the start of that move action. After that move action, allocate 3 damage points to that fighter and to each other enemy fighter within 2\" of that fighter. Cremate each fighter taken down by this ability.",
-    "runemarks": []
-  }
+    {
+        "_id": "22050b34",
+        "name": "Balefire Cremation",
+        "warband": "Pyregheists",
+        "cost": "passive",
+        "description": "When an ability tells you to cremate a fighter, remove that fighter from the battlefield and place a Pyre token at the centre of the space occupied by that fighter. At the end of the battle round, after determining control of objectives, allocate 3 damage to each enemy fighter within 1\" of the centre of one or more Pyre tokens.",
+        "runemarks": []
+    },
+    {
+        "_id": "78f7d995",
+        "name": "Fan the Flames",
+        "warband": "Pyregheists",
+        "cost": "double",
+        "description": "Add 1 to the damage points allocated by each hit and each critical hit from the next melee attack action made by this fighter this activation.",
+        "runemarks": []
+    },
+    {
+        "_id": "20a38f4f",
+        "name": "Pyrerobber's Curse",
+        "warband": "Pyregheists",
+        "cost": "double",
+        "description": "Until the end of this fighter's activation, add 1 to the Strength characteristic of attack actions made by this fighter. Until the end of this fighter's activation, when their attack action takes down an enemy fighter, cremate that enemy fighter.",
+        "runemarks": [
+            "frenzied"
+        ]
+    },
+    {
+        "_id": "779e2be9",
+        "name": "Unblinking Guardian",
+        "warband": "Pyregheists",
+        "cost": "double",
+        "description": "Until the end of the battle round, add 1 to the Toughness characteristic of friendly fighters with the Elite or Hero runemarks while they are within 3\" of this fighter.",
+        "runemarks": [
+            "elite"
+        ]
+    },
+    {
+        "_id": "85b75c37",
+        "name": "Light the Pyre",
+        "warband": "Pyregheists",
+        "cost": "triple",
+        "description": "A fighter can only use this ability when their attack action takes down an enemy fighter. Cremate that enemy fighter.",
+        "runemarks": []
+    },
+    {
+        "_id": "6bb4417d",
+        "name": "Soulblaze",
+        "warband": "Pyregheists",
+        "cost": "triple",
+        "description": "A fighter can only use this ability if an enemy fighter has been taken down this battle round. Pick a number of visible friendly fighters with the Pyregheists runemark equal to half the value of this ability (rounding up). Each fighter you picked can make a bonus move action or a bonus attack action (some can make a bonus move action and others can make a bonus attack action).",
+        "runemarks": [
+            "hero"
+        ]
+    },
+    {
+        "_id": "ad5d0eb1",
+        "name": "Agonising Penance",
+        "warband": "Pyregheists",
+        "cost": "quad",
+        "description": "Pick a visible enemy fighter within 6\" of this fighter. That enemy fighter makes a bonus move action directly towards the closest other fighter from their warband, as if they were jumping, a number of inches equal to the value of this ability. When doing so, they can move away from enemy fighters within 1\" at the start of that move action. After that move action, allocate 3 damage points to that fighter and to each other enemy fighter within 2\" of that fighter. Cremate each fighter taken down by this ability.",
+        "runemarks": []
+    },
+    {
+        "_id": "b227b66a",
+        "name": "Pyres of Victory",
+        "warband": "Pyregheists",
+        "cost": "battletrait",
+        "description": "At the end of each battle round, each player whose warband has this battle trait can roll a dice for each friendly Pyre token on the battlefield. For each roll of 3+, add one wild dice to that player's saved wild dice.",
+        "runemarks": []
+    }
 ]

--- a/data/Death/royal_beastflayers_abilities.json
+++ b/data/Death/royal_beastflayers_abilities.json
@@ -64,5 +64,13 @@
         "cost": "reaction",
         "description": "After a visible enemy fighter within 1\" of this fighter makes a disengage action, allocate D3 damage points to that fighter.",
         "runemarks": []
+    },
+    {
+        "_id": "3bd91588",
+        "name": "The Hounds Bay",
+        "warband": "Royal Beastflayers",
+        "cost": "battletrait",
+        "description": "After an enemy fighter has been taken down by a melee attack action made by a friendly fighter with this battle trait that has the Beast runemark, pick another fighter in your warband. That fighter can make a bonus move action of up to 3\".",
+        "runemarks": []
     }
 ]

--- a/data/Death/soulblight_gravelords_abilities.json
+++ b/data/Death/soulblight_gravelords_abilities.json
@@ -152,6 +152,14 @@
         "runemarks": []
     },
     {
+        "_id": "c5973665",
+        "name": "Sanguine Glory",
+        "warband": "Soulblight Gravelords",
+        "cost": "battletrait",
+        "description": "Each time a friendly fighter with this battle trait uses the \"Thirst for Blood\" ability, if that value of that ability is 1 or 2, increase the value of that ability to 3.",
+        "runemarks": []
+    },
+    {
         "_id": "235d62bf",
         "name": "Fiendish Lure",
         "warband": "The Crimson Court",

--- a/data/Death/teratic_cohort_abilities.json
+++ b/data/Death/teratic_cohort_abilities.json
@@ -1,12 +1,11 @@
 [
- {
+    {
         "_id": "mbqlebrx",
         "name": "Predatory Ravage",
         "warband": "Teratic Cohort",
         "cost": "reaction",
         "description": "A fighter with the Teratic Cohort runemark can make this reaction after all the damage points from an enemy fighter's melee attack action have been allocated to them. The reacting fighter can make a melee attack action that targets the attacker. When a fighter uses this reaction, you can discard one of your saved wild dice. If you do not, subtract 1 from the attacks characteristic of that attack action, and subtract 1 from the damage points allocated by each hit and critical hit from that attack action (to a minimum of 1).",
-        "runemarks": [
-        ]
+        "runemarks": []
     },
     {
         "_id": "719op2wr",
@@ -52,8 +51,7 @@
         "warband": "Teratic Cohort",
         "cost": "triple",
         "description": "One critical hit from the next melee attack action made by this fighter in this activation scores 1 additional critical hit. When a fighter uses this ability, you can discard two of your saved wild dice. If you do so, one critical hit from the next melee attack action made by this fighter in this activation scores 2 additional critical hits instead.",
-        "runemarks": [
-        ]
+        "runemarks": []
     },
     {
         "_id": "b1sespft",
@@ -64,6 +62,13 @@
         "runemarks": [
             "elite"
         ]
+    },
+    {
+        "_id": "a0bca675",
+        "name": "Predatory Outriders",
+        "warband": "Teratic Cohort",
+        "cost": "battletrait",
+        "description": "Before deployment, you can pick a friendly battle group that is not In reserve. Fighters from that battle group can deploy within 6\" of their deployment point, but if they do so, must be deployed more than 6\" from each enemy fighter.",
+        "runemarks": []
     }
-
 ]

--- a/data/Destruction/bonesplitterz_abilities.json
+++ b/data/Destruction/bonesplitterz_abilities.json
@@ -118,6 +118,14 @@
         "runemarks": []
     },
     {
+        "_id": "ba1dfa32",
+        "name": "Primal Beliefs",
+        "warband": "Bonesplitterz",
+        "cost": "battletrait",
+        "description": "When a player whose warband has this battle trait makes an initiative roll, before initiative is determined, they can re-roll each result of 1.",
+        "runemarks": []
+    },
+    {
         "_id": "7bb09959",
         "name": "An Eye for Weakness",
         "warband": "Hedkrakka's Madmob",

--- a/data/Destruction/destruction_abilities.json
+++ b/data/Destruction/destruction_abilities.json
@@ -127,5 +127,13 @@
         "runemarks": [
             "bulwark"
         ]
+    },
+    {
+        "_id": "4c2fa638",
+        "name": "Relentless Destroyers",
+        "warband": "destruction",
+        "cost": "battletrait",
+        "description": "When a friendly fighter with this battle trait makes a melee attack action, the target cannot add 1 to their Toughness for being in cover.",
+        "runemarks": []
     }
 ]

--- a/data/Destruction/gloomspite_gitz_abilities.json
+++ b/data/Destruction/gloomspite_gitz_abilities.json
@@ -207,6 +207,14 @@
         ]
     },
     {
+        "_id": "0a491014",
+        "name": "Da Bad Moon Rises",
+        "warband": "Gloomspite Gitz",
+        "cost": "battletrait",
+        "description": "At the start of a battle round, each player whose warband has this battle trait can roll a dice, starting with the attacker. On a 2+, pick 1 of your opponent's, or your own [double]s, [triple]s, or [quad]s. Change the value of those ability dice to the result of the dice roll.",
+        "runemarks": []
+    },
+    {
         "_id": "a523f4de",
         "name": "Questin' Knight",
         "warband": "Grinkrak's Looncourt",

--- a/data/Destruction/gorger_mawpack_abilities.json
+++ b/data/Destruction/gorger_mawpack_abilities.json
@@ -62,5 +62,13 @@
         "cost": "quad",
         "description": "Until the end of the battle round, this fighter is considered to have the Beast runemark. If this fighter is carrying treasure, they drop that treasure. This fighter can make 1 bonus melee attack action for each visible enemy fighter within 1\" of them. Each of these attack actions must target a different fighter.",
         "runemarks": []
+    },
+    {
+        "_id": "2e2fb526",
+        "name": "Ravenous Gording",
+        "warband": "Gorger Mawpack",
+        "cost": "battletrait",
+        "description": "After an enemy fighter has been taken down by a melee attack action made by a friendly fighter with this battle trait, remove D£ damage points allocated to that friendly fighter.",
+        "runemarks": []
     }
 ]

--- a/data/Destruction/ironjawz_abilities.json
+++ b/data/Destruction/ironjawz_abilities.json
@@ -108,6 +108,14 @@
         "runemarks": []
     },
     {
+        "_id": "ce54fd3b",
+        "name": "Enough Messin'",
+        "warband": "Ironjawz",
+        "cost": "battletrait",
+        "description": "Each time an enemy fighter makes a wait action, each player whose warband has this battle trait can pick one friendly fighter. That fighter makes a bonus move action of up to 3\".",
+        "runemarks": []
+    },
+    {
         "_id": "928413af",
         "name": "Dead 'Ard",
         "warband": "Ironskull's Boyz",

--- a/data/Destruction/kruleboyz_abilities.json
+++ b/data/Destruction/kruleboyz_abilities.json
@@ -30,6 +30,46 @@
         ]
     },
     {
+        "_id": "574b4620",
+        "name": "Leave Ya Bleedin'",
+        "warband": "Daggok's Stab-ladz",
+        "cost": "double",
+        "description": "A fighter can only use this ability if an enemy fighter was allocated damage points by an attack action made by them this activation. Roll a dice for each wound allocated to that enemy fighter at the end of the battle round. For each 4+, allocate 1 damage point to that fighter.",
+        "runemarks": [
+            "frenzied"
+        ]
+    },
+    {
+        "_id": "eaba1b07",
+        "name": "Hookin' Your Guts",
+        "warband": "Daggok's Stab-ladz",
+        "cost": "double",
+        "description": "Until the end of the battle round, after an enemy fighter makes a disengage action that began within 3\" of this fighter, allocate D6 damage points to that fighter.",
+        "runemarks": [
+            "brute"
+        ]
+    },
+    {
+        "_id": "cc8aa230",
+        "name": "Roar of Kragnos",
+        "warband": "Daggok's Stab-ladz",
+        "cost": "triple",
+        "description": "Until the end of the battle round, add 1 to the Attacks characteristic of melee attack actions made by visible friendly fighters while they are within 6\" of this fighter.",
+        "runemarks": [
+            "icon-bearer"
+        ]
+    },
+    {
+        "_id": "6b7e69c6",
+        "name": "Stealin' Your Finks",
+        "warband": "Daggok's Stab-ladz",
+        "cost": "quad",
+        "description": "A fighter can only use this ability if an enemy fighter has been taken down by an attack action made by them this activation. Gain a number of wild dice equal to the value of this ability, then this fighter makes a bonus move action.",
+        "runemarks": [
+            "hero"
+        ]
+    },
+    {
         "_id": "c867eb77",
         "name": "Aimed Shot",
         "warband": "Kruleboyz",
@@ -132,43 +172,11 @@
         "runemarks": []
     },
     {
-        "_id": "574b4620",
-        "name": "Leave Ya Bleedin'",
-        "warband": "Daggok's Stab-ladz",
-        "cost": "double",
-        "description": "A fighter can only use this ability if an enemy fighter was allocated damage points by an attack action made by them this activation. Roll a dice for each wound allocated to that enemy fighter at the end of the battle round. For each 4+, allocate 1 damage point to that fighter.",
-        "runemarks": [
-            "frenzied"
-        ]
-    },
-    {
-        "_id": "eaba1b07",
-        "name": "Hookin' Your Guts",
-        "warband": "Daggok's Stab-ladz",
-        "cost": "double",
-        "description": "Until the end of the battle round, after an enemy fighter makes a disengage action that began within 3\" of this fighter, allocate D6 damage points to that fighter.",
-        "runemarks": [
-            "brute"
-        ]
-    },
-    {
-        "_id": "cc8aa230",
-        "name": "Roar of Kragnos",
-        "warband": "Daggok's Stab-ladz",
-        "cost": "triple",
-        "description": "Until the end of the battle round, add 1 to the Attacks characteristic of melee attack actions made by visible friendly fighters while they are within 6\" of this fighter.",
-        "runemarks": [
-            "icon-bearer"
-        ]
-    },
-    {
-        "_id": "6b7e69c6",
-        "name": "Stealin' Your Finks",
-        "warband": "Daggok's Stab-ladz",
-        "cost": "quad",
-        "description": "A fighter can only use this ability if an enemy fighter has been taken down by an attack action made by them this activation. Gain a number of wild dice equal to the value of this ability, then this fighter makes a bonus move action.",
-        "runemarks": [
-            "hero"
-        ]
+        "_id": "b47a0436",
+        "name": "Stick 'Em Good and Quick",
+        "warband": "Kruleboyz",
+        "cost": "battletrait",
+        "description": "Once per battle round, pick a friendly fighter with this battle trait. For that battle round, after that fighter's activation, you can pick an enemy fighter that was allocated 1 or more damage points by a melee attack action made by the fighter you picked. Allocated D3 damage points to that enemy fighter.",
+        "runemarks": []
     }
 ]

--- a/data/Destruction/kruleboyz_monsta-killaz_abilities.json
+++ b/data/Destruction/kruleboyz_monsta-killaz_abilities.json
@@ -68,5 +68,13 @@
         "runemarks": [
             "trapper"
         ]
+    },
+    {
+        "_id": "bf2395e5",
+        "name": "'Orrible Trap",
+        "warband": "Kruleboyz Monsta-killaz",
+        "cost": "battletrait",
+        "description": "When a friendly fighter with this battle trait uses the Krule Trap reaction, if the enemy fighter has the Monster runemark, add 2 to the roll.",
+        "runemarks": []
     }
 ]

--- a/data/Destruction/ogor_mawtribes_abilities.json
+++ b/data/Destruction/ogor_mawtribes_abilities.json
@@ -182,5 +182,13 @@
         "runemarks": [
             "ferocious"
         ]
+    },
+    {
+        "_id": "cc988df4",
+        "name": "Ogor Mawtribes",
+        "warband": "Ogor Mawtribes",
+        "cost": "battletrait",
+        "description": "Friendly fighters with this battle trait and the Brute or Agile runemarks can make the following action:Devour Corpse:Pick an enemy fighter that is taken down and roll a dice. Remove a number of damage points from this fighter equal to the roll. An enemy fighter cannot be picked as the target of this action more than once per battle.",
+        "runemarks": []
     }
 ]

--- a/data/Order/cities_of_sigmar_castelite_hosts_abilities.json
+++ b/data/Order/cities_of_sigmar_castelite_hosts_abilities.json
@@ -1,5 +1,37 @@
 [
     {
+        "_id": "387652bc",
+        "name": "Ultimate Resistor",
+        "warband": "Brethren of the Bolt",
+        "cost": "reaction",
+        "description": "A fighter can make this reaction when they are targeted by a melee attack action but before the hit rolls are made. Subtract 1 from the damage points allocated to this fighter by each hit from that attack action (to a minimum of 1).",
+        "runemarks": []
+    },
+    {
+        "_id": "2239ee7f",
+        "name": "Thunderous Blast",
+        "warband": "Brethren of the Bolt",
+        "cost": "double",
+        "description": "Pick a visible enemy fighter within 3\" of this fighter and roll 3 dice. For each roll of 3+, allocate a number of damage points to that fighter equal to half the value of this ability (rounding up). You can pick an enemy fighter within 3\" of another visible friendly fighter with the Brethren of the Bolt runemark if that friendly fighter is within 6\" of this fighter.",
+        "runemarks": []
+    },
+    {
+        "_id": "f44687c7",
+        "name": "Furious Abandon",
+        "warband": "Brethren of the Bolt",
+        "cost": "triple",
+        "description": "This fighter can make a bonus move action up to a number of inches equal to the value of this ability. Then, they can make a bonus attack action.",
+        "runemarks": []
+    },
+    {
+        "_id": "5f9ed484",
+        "name": "Unleashing His Fury",
+        "warband": "Brethren of the Bolt",
+        "cost": "quad",
+        "description": "This fighter makes a bonus ranged attack action. When that attack action is made, you can pick another friendly fighter that is visible to the attacker to be part of a chain. Then, you can pick a third friendly fighter that is within 6\" of and visible to the second fighter to be the next part of the chain, and so on. Once the last fighter in the chain is picked, you can measure the range of that bonus attack action from the last fighter in the chain. Add 1 to the Attacks, Strength and Damage characteristics of that weapon for each fighter in the chain. Each fighter in the chain must have the Brethren of the Bolt runemark.",
+        "runemarks": []
+    },
+    {
         "_id": "be7e8fe2",
         "name": "Castelite Wall",
         "warband": "Cities of Sigmar: Castelite Hosts",
@@ -121,35 +153,11 @@
         ]
     },
     {
-        "_id": "387652bc",
-        "name": "Ultimate Resistor",
-        "warband": "Brethren of the Bolt",
-        "cost": "reaction",
-        "description": "A fighter can make this reaction when they are targeted by a melee attack action but before the hit rolls are made. Subtract 1 from the damage points allocated to this fighter by each hit from that attack action (to a minimum of 1).",
-        "runemarks": []
-    },
-    {
-        "_id": "2239ee7f",
-        "name": "Thunderous Blast",
-        "warband": "Brethren of the Bolt",
-        "cost": "double",
-        "description": "Pick a visible enemy fighter within 3\" of this fighter and roll 3 dice. For each roll of 3+, allocate a number of damage points to that fighter equal to half the value of this ability (rounding up). You can pick an enemy fighter within 3\" of another visible friendly fighter with the Brethren of the Bolt runemark if that friendly fighter is within 6\" of this fighter.",
-        "runemarks": []
-    },
-    {
-        "_id": "f44687c7",
-        "name": "Furious Abandon",
-        "warband": "Brethren of the Bolt",
-        "cost": "triple",
-        "description": "This fighter can make a bonus move action up to a number of inches equal to the value of this ability. Then, they can make a bonus attack action.",
-        "runemarks": []
-    },
-    {
-        "_id": "5f9ed484",
-        "name": "Unleashing His Fury",
-        "warband": "Brethren of the Bolt",
-        "cost": "quad",
-        "description": "This fighter makes a bonus ranged attack action. When that attack action is made, you can pick another friendly fighter that is visible to the attacker to be part of a chain. Then, you can pick a third friendly fighter that is within 6\" of and visible to the second fighter to be the next part of the chain, and so on. Once the last fighter in the chain is picked, you can measure the range of that bonus attack action from the last fighter in the chain. Add 1 to the Attacks, Strength and Damage characteristics of that weapon for each fighter in the chain. Each fighter in the chain must have the Brethren of the Bolt runemark.",
+        "_id": "1586d745",
+        "name": "Dawnbringer Zealots",
+        "warband": "Cities of Sigmar: Castelite Hosts",
+        "cost": "battletrait",
+        "description": "At the end of each battle round, pick a friendly fighter with this battle trait that is on the battlefield. You can remove up to D3 damage points allocated to that fighter. Remove 1 additional damage point if that fighter is within 3\" of an objective, carrying treasure and/or within 1\" of an obstacle.",
         "runemarks": []
     }
 ]

--- a/data/Order/cities_of_sigmar_darkling_covens_abilities.json
+++ b/data/Order/cities_of_sigmar_darkling_covens_abilities.json
@@ -89,5 +89,13 @@
             "hero",
             "mystic"
         ]
+    },
+    {
+        "_id": "68830269",
+        "name": "Dawnbringer Zealots",
+        "warband": "Cities of Sigmar: Darkling Covens",
+        "cost": "battletrait",
+        "description": "At the end of each battle round, pick a friendly fighter with this battle trait that is on the battlefield. You can remove up to D3 damage points allocated to that fighter. Remove 1 additional damage point if that fighter is within 3\" of an objective, carrying treasure and/or within 1\" of an obstacle.",
+        "runemarks": []
     }
 ]

--- a/data/Order/cities_of_sigmar_dispossessed_abilities.json
+++ b/data/Order/cities_of_sigmar_dispossessed_abilities.json
@@ -93,5 +93,13 @@
         "runemarks": [
             "brute"
         ]
+    },
+    {
+        "_id": "01fee5b7",
+        "name": "Dawnbringer Zealots",
+        "warband": "Cities of Sigmar: Dispossessed",
+        "cost": "battletrait",
+        "description": "At the end of each battle round, pick a friendly fighter with this battle trait that is on the battlefield. You can remove up to D3 damage points allocated to that fighter. Remove 1 additional damage point if that fighter is within 3\" of an objective, carrying treasure and/or within 1\" of an obstacle.",
+        "runemarks": []
     }
 ]

--- a/data/Order/daughters_of_khaine_abilities.json
+++ b/data/Order/daughters_of_khaine_abilities.json
@@ -118,6 +118,14 @@
         "runemarks": []
     },
     {
+        "_id": "634e3c1f",
+        "name": "Jubilant Bloodletting",
+        "warband": "Daughters of Khaine",
+        "cost": "battletrait",
+        "description": "When a friendly fighter with this battle trait makes a melee attack action, after the hit rolls have been made, if you scored one or more critical hits and one or more hits and/or critical hits, you can pick a [double], [triple], or [quad] you have. Add 2 to the value of that ability dice, to a maximum of 6.",
+        "runemarks": []
+    },
+    {
         "_id": "2c353eb1",
         "name": "Peerless Combatant",
         "warband": "Gryselle's Arenai",

--- a/data/Order/fyreslayers_abilities.json
+++ b/data/Order/fyreslayers_abilities.json
@@ -138,14 +138,6 @@
         "runemarks": []
     },
     {
-        "_id": "3382fbfd",
-        "name": "The Chosen Kin",
-        "warband": "The Chosen Axes",
-        "cost": "double",
-        "description": "A fighter can use this ability only if they are within 6\" of a visible friendly Fjul-Grimnir. Until the end of this fighter's activation, add 2 to the Attacks characteristic of attack actions made by this fighter that have the Axe runemark.",
-        "runemarks": []
-    },
-    {
         "_id": "8c393095",
         "name": "Lodge-fire Blaze",
         "warband": "Fyreslayers",
@@ -154,5 +146,21 @@
         "runemarks": [
             "destroyer"
         ]
+    },
+    {
+        "_id": "38e0f5e7",
+        "name": "Runic Momentum",
+        "warband": "Fyreslayers",
+        "cost": "battletrait",
+        "description": "After a friendly fighter with this battle trait uses an ability, add 1 to their Move characteristic for the next move action they make this activation.",
+        "runemarks": []
+    },
+    {
+        "_id": "3382fbfd",
+        "name": "The Chosen Kin",
+        "warband": "The Chosen Axes",
+        "cost": "double",
+        "description": "A fighter can use this ability only if they are within 6\" of a visible friendly Fjul-Grimnir. Until the end of this fighter's activation, add 2 to the Attacks characteristic of attack actions made by this fighter that have the Axe runemark.",
+        "runemarks": []
     }
 ]

--- a/data/Order/hunters_of_huanchi_abilities.json
+++ b/data/Order/hunters_of_huanchi_abilities.json
@@ -68,5 +68,13 @@
         "runemarks": [
             "agile"
         ]
+    },
+    {
+        "_id": "257f7546",
+        "name": "Hidden Hunters",
+        "warband": "Hunters of Huanchi",
+        "cost": "battletrait",
+        "description": "After deployment, each player whose warband has this battle trait can pick a friendly fighter with this battle trait from each friendly battle group that is on the battlefield. One at a time, remove those fighters from the battlefield and pick a different battle group. Then deploy that fighter as if it were part of that battle group.",
+        "runemarks": []
     }
 ]

--- a/data/Order/idoneth_deepkin_abilities.json
+++ b/data/Order/idoneth_deepkin_abilities.json
@@ -1,5 +1,45 @@
 [
     {
+        "_id": "6d695b7a",
+        "name": "Ink Jet",
+        "warband": "Cyreni's Razors",
+        "cost": "reaction",
+        "description": "A fighter can make this reaction after they are targeted by a melee attack action but before the hit rolls are made. For each hit roll from that attack action that misses, after that attack action is resolved, you can move this fighter up to 2\". In addition, if all of the hit rolls missed, that enemy fighter cannot make attack actions until the end of the battle round.",
+        "runemarks": [
+            "beast"
+        ]
+    },
+    {
+        "_id": "7479b3ed",
+        "name": "Hurl Lanmari Blade",
+        "warband": "Cyreni's Razors",
+        "cost": "double",
+        "description": "Add the value of this ability to the Range characteristic of the next melee attack action made by this fighter this activation. After that attack action, this fighter cannot make melee attack actions for the rest of this activation.",
+        "runemarks": [
+            "minion"
+        ]
+    },
+    {
+        "_id": "06b33bb6",
+        "name": "Hammertide",
+        "warband": "Cyreni's Razors",
+        "cost": "triple",
+        "description": "Pick a corner of the battlefield and draw a straight line 1mm wide between the centre of this fighter's base and that corner. Enemy fighters whose base touches that line cannot jump, fly or climb until the end of this battle round. In addition, roll a number of dice equal to the value of this ability for each such enemy fighter. Allocate 1 damage point to that fighter for each roll of 3+.",
+        "runemarks": [
+            "hero"
+        ]
+    },
+    {
+        "_id": "c5c07e49",
+        "name": "Crushing Wrap",
+        "warband": "Cyreni's Razors",
+        "cost": "quad",
+        "description": "A fighter can only use this ability before it would make a melee attack action. Roll 8 dice. For each roll of 3+, add 1 to this fighter's Strength characteristic for that attack action and allocate 2 damage points to the target of that attack action. If the target is taken out of action, the melee attack action has no effect.",
+        "runemarks": [
+            "beast"
+        ]
+    },
+    {
         "_id": "efc50c98",
         "name": "Soulnet",
         "warband": "Elathain's Soulraid",
@@ -141,43 +181,11 @@
         "runemarks": []
     },
     {
-        "_id": "6d695b7a",
-        "name": "Ink Jet",
-        "warband": "Cyreni's Razors",
-        "cost": "reaction",
-        "description": "A fighter can make this reaction after they are targeted by a melee attack action but before the hit rolls are made. For each hit roll from that attack action that misses, after that attack action is resolved, you can move this fighter up to 2\". In addition, if all of the hit rolls missed, that enemy fighter cannot make attack actions until the end of the battle round.",
-        "runemarks": [
-            "beast"
-        ]
-    },
-    {
-        "_id": "7479b3ed",
-        "name": "Hurl Lanmari Blade",
-        "warband": "Cyreni's Razors",
-        "cost": "double",
-        "description": "Add the value of this ability to the Range characteristic of the next melee attack action made by this fighter this activation. After that attack action, this fighter cannot make melee attack actions for the rest of this activation.",
-        "runemarks": [
-            "minion"
-        ]
-    },
-    {
-        "_id": "06b33bb6",
-        "name": "Hammertide",
-        "warband": "Cyreni's Razors",
-        "cost": "triple",
-        "description": "Pick a corner of the battlefield and draw a straight line 1mm wide between the centre of this fighter's base and that corner. Enemy fighters whose base touches that line cannot jump, fly or climb until the end of this battle round. In addition, roll a number of dice equal to the value of this ability for each such enemy fighter. Allocate 1 damage point to that fighter for each roll of 3+.",
-        "runemarks": [
-            "hero"
-        ]
-    },
-    {
-        "_id": "c5c07e49",
-        "name": "Crushing Wrap",
-        "warband": "Cyreni's Razors",
-        "cost": "quad",
-        "description": "A fighter can only use this ability before it would make a melee attack action. Roll 8 dice. For each roll of 3+, add 1 to this fighter's Strength characteristic for that attack action and allocate 2 damage points to the target of that attack action. If the target is taken out of action, the melee attack action has no effect.",
-        "runemarks": [
-            "beast"
-        ]
+        "_id": "f9e19991",
+        "name": "Power of the Tides",
+        "warband": "Idoneth Deepkin",
+        "cost": "battletrait",
+        "description": "In battle rounds 1 and 2, add 1 to the Move characteristic of friendly fighters with this battle trait. In battle rounds 3 and 4, add 1 to the Strength characteristic of melee attack actions made by friendly fighters with the battle trait.",
+        "runemarks": []
     }
 ]

--- a/data/Order/khainite_shadowstalkers_abilities.json
+++ b/data/Order/khainite_shadowstalkers_abilities.json
@@ -62,5 +62,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction when an enemy fighter finishes a move action within 3\" of them. Note the distance between this fighter and the enemy fighter that made the move action. Remove this fighter from the battlefield and then set this fighter up on a platform or the battlefield floor no further from the enemy fighter that made the move action.",
         "runemarks": []
+    },
+    {
+        "_id": "1242e8e7",
+        "name": "Swarming Shadows",
+        "warband": "Khainite Shadowstalkers",
+        "cost": "battletrait",
+        "description": "At the end of each battle round, each player whose warband has this battle trait can pick two friendly fighters that are within 9\" of each other, more than 3\" from each enemy fighter and are not carrying treasure. Place each friendly fighter in the position the other fighter was in when they were picked.",
+        "runemarks": []
     }
 ]

--- a/data/Order/kharadron_overlords_abilities.json
+++ b/data/Order/kharadron_overlords_abilities.json
@@ -109,14 +109,6 @@
         "runemarks": []
     },
     {
-        "_id": "cce1c9d6",
-        "name": "Win Recognition",
-        "warband": "Thundrik's Profiteers",
-        "cost": "triple",
-        "description": "A fighter can use this ability only if they are within 6\" of a visible friendly Bjorgen Thundrik and it is the third battle round or later.  This fighter can make a bonus attack action.",
-        "runemarks": []
-    },
-    {
         "_id": "9c64c8f5",
         "name": "I Think You'll Find...",
         "warband": "Kharadron Overlords",
@@ -125,5 +117,21 @@
         "runemarks": [
             "icon-bearer"
         ]
+    },
+    {
+        "_id": "274b8b3a",
+        "name": "A Good Deal",
+        "warband": "Kharadron Overlords",
+        "cost": "battletrait",
+        "description": "Once per battle round, after a friendly fighter with this battle trait is targeted by an attack action but before the hit rolls are made, you can make a deal. If you do so, add one wild dice to your opponent's saved wild dice. Then subtract 2 from the damage points allocated to that fighter by each hit and each critical hit from that attack action (to a minimum of 1)..",
+        "runemarks": []
+    },
+    {
+        "_id": "cce1c9d6",
+        "name": "Win Recognition",
+        "warband": "Thundrik's Profiteers",
+        "cost": "triple",
+        "description": "A fighter can use this ability only if they are within 6\" of a visible friendly Bjorgen Thundrik and it is the third battle round or later.  This fighter can make a bonus attack action.",
+        "runemarks": []
     }
 ]

--- a/data/Order/lumineth_realm-lords_abilities.json
+++ b/data/Order/lumineth_realm-lords_abilities.json
@@ -134,6 +134,14 @@
         "runemarks": []
     },
     {
+        "_id": "fa01e17f",
+        "name": "Aetherquartz Reserves",
+        "warband": "Lumineth Realm-lords",
+        "cost": "battletrait",
+        "description": "At the start of the first battle round, each player whose warband has this battle trait can pick a friendly fighter. That fighter has an aethrquartz reserve. Once per battle, that fighter can use their aetherquatz reserve. When they do so, the next time that fighter uses an ability, you can treat one [double] you have as a [triple], or one [triple] you have as a [quad].",
+        "runemarks": []
+    },
+    {
         "_id": "927cb4b0",
         "name": "Dazzling Light",
         "warband": "Myari's Purifiers",

--- a/data/Order/order_abilities.json
+++ b/data/Order/order_abilities.json
@@ -94,5 +94,13 @@
         "runemarks": [
             "grombrindal"
         ]
+    },
+    {
+        "_id": "473ca1b2",
+        "name": "Courageous Defenders",
+        "warband": "order",
+        "cost": "battletrait",
+        "description": "When a friendly fighter with this battle trait makes the 'Take Cover' reaction, critical hits become hits on a roll of 3+ instead of 4+.",
+        "runemarks": []
     }
 ]

--- a/data/Order/seraphon_abilities.json
+++ b/data/Order/seraphon_abilities.json
@@ -120,26 +120,6 @@
         "runemarks": []
     },
     {
-        "_id": "fa891e0e",
-        "name": "Chameleon Ambush",
-        "warband": "The Starblood Stalkers",
-        "cost": "double",
-        "description": "This fighter can use this ability only if there are no visible enemy fighters within 12\" of this fighter. This fighter makes a bonus move action.",
-        "runemarks": [
-            "scout"
-        ]
-    },
-    {
-        "_id": "da1dd1e6",
-        "name": "Imbue with Azyrite Energy",
-        "warband": "The Starblood Stalkers",
-        "cost": "triple",
-        "description": "Until the end of the battle round, add 1 to the Move and Toughness characteristics of friendly fighters while they are within 9\" of this fighter.",
-        "runemarks": [
-            "hero"
-        ]
-    },
-    {
         "_id": "2ba76301",
         "name": "Predatory Leap",
         "warband": "Seraphon",
@@ -179,6 +159,34 @@
         "runemarks": [
             "minion",
             "mount"
+        ]
+    },
+    {
+        "_id": "d4de5fe6",
+        "name": "Seraphon",
+        "warband": "Seraphon",
+        "cost": "battletrait",
+        "description": "After you pick your warband, pick either Coalesced or Starborne and gain the corresponding battle trait listed below:Coalesced:Friendly fighters with this battle trait can add a 1 to the value of any [triple] spent to use the Tearing bite ability, to a maximum of 6. Starborne:Fighters with this battle trait can make the \"Starborn\" reaction when they are targeted by melee and ranged attack actions.",
+        "runemarks": []
+    },
+    {
+        "_id": "fa891e0e",
+        "name": "Chameleon Ambush",
+        "warband": "The Starblood Stalkers",
+        "cost": "double",
+        "description": "This fighter can use this ability only if there are no visible enemy fighters within 12\" of this fighter. This fighter makes a bonus move action.",
+        "runemarks": [
+            "scout"
+        ]
+    },
+    {
+        "_id": "da1dd1e6",
+        "name": "Imbue with Azyrite Energy",
+        "warband": "The Starblood Stalkers",
+        "cost": "triple",
+        "description": "Until the end of the battle round, add 1 to the Move and Toughness characteristics of friendly fighters while they are within 9\" of this fighter.",
+        "runemarks": [
+            "hero"
         ]
     }
 ]

--- a/data/Order/stormcast_eternals_questor_soulsworn_abilities.json
+++ b/data/Order/stormcast_eternals_questor_soulsworn_abilities.json
@@ -62,5 +62,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction when they are targeted by a melee attack action, after the damage is totalled but before it is allocated to this fighter, if it is enough for this fighter to be taken down.  Pick another friendly fighter.  That fighter makes a bonus move action or a bonus attack action.",
         "runemarks": []
+    },
+    {
+        "_id": "57e67ede",
+        "name": "Heroes Without Limits",
+        "warband": "Stormcast Eternals Questor Soulsworn",
+        "cost": "battletrait",
+        "description": "Fighters with this battle trait can use multiple abilities each activation. Such fighters can use the same ability more than once, and can use multiple abilities when they would normally only be able to use one. Where abilities grant bonus actions, such abilities are used one at a time and are fully resolved before another ability can be used.",
+        "runemarks": []
     }
 ]

--- a/data/Order/stormcast_eternals_sacrosanct_chamber_abilities.json
+++ b/data/Order/stormcast_eternals_sacrosanct_chamber_abilities.json
@@ -108,6 +108,14 @@
         "runemarks": []
     },
     {
+        "_id": "af254288",
+        "name": "Scions of the Storm",
+        "warband": "Stormcast Eternals Sacrosanct Chamber",
+        "cost": "battletrait",
+        "description": "After deployment, you can pick a friendly fighter with this battle trait. If that fighter is on the battlefield, remove them from the battlefield. At the start of the second battle round onwards, starting with the attacker, you can place that fighter on the battlefield more than 5\" from each enemy fighter and more than 3\" from each objective and treasure token.",
+        "runemarks": []
+    },
+    {
         "_id": "38af3e28",
         "name": "Storm of Eldritch Lightning",
         "warband": "Stormsire's Cursebreakers",

--- a/data/Order/stormcast_eternals_thunderstrike_stormcast_abilities.json
+++ b/data/Order/stormcast_eternals_thunderstrike_stormcast_abilities.json
@@ -169,6 +169,14 @@
         "runemarks": []
     },
     {
+        "_id": "6c0ac666",
+        "name": "Scions of the Storm",
+        "warband": "Stormcast Eternals Thunderstrike Stormcast",
+        "cost": "battletrait",
+        "description": "After deployment, you can pick a friendly fighter with this battle trait. If that fighter is on the battlefield, remove them from the battlefield. At the start of the second battle round onwards, starting with the attacker, you can place that fighter on the battlefield more than 5\" from each enemy fighter and more than 3\" from each objective and treasure token.",
+        "runemarks": []
+    },
+    {
         "_id": "b0a0b989",
         "name": "Lantern Astrala",
         "warband": "Xandire's Truthseekers",

--- a/data/Order/stormcast_eternals_vanguard_auxiliary_chamber_abilities.json
+++ b/data/Order/stormcast_eternals_vanguard_auxiliary_chamber_abilities.json
@@ -109,6 +109,14 @@
         "runemarks": []
     },
     {
+        "_id": "f29b1feb",
+        "name": "Scions of the Storm",
+        "warband": "Stormcast Eternals Vanguard Auxiliary Chamber",
+        "cost": "battletrait",
+        "description": "After deployment, you can pick a friendly fighter with this battle trait. If that fighter is on the battlefield, remove them from the battlefield. At the start of the second battle round onwards, starting with the attacker, you can place that fighter on the battlefield more than 5\" from each enemy fighter and more than 3\" from each objective and treasure token.",
+        "runemarks": []
+    },
+    {
         "_id": "6a8cfa78",
         "name": "Guided by the Astral Compass",
         "warband": "The Farstriders",

--- a/data/Order/stormcast_eternals_warrior_chamber_abilities.json
+++ b/data/Order/stormcast_eternals_warrior_chamber_abilities.json
@@ -148,5 +148,13 @@
         "cost": "reaction",
         "description": "A fighter can make this reaction when they are targeted by a melee attack action, after the damage is totalled but before it is allocated to this fighter, if it is enough for this fighter to be taken down. Allocate D6 damage points to their attacker. Fighters with the Beast runemark or both the Scout and Fly  runemarks cannot make this reaction.",
         "runemarks": []
+    },
+    {
+        "_id": "e18be04c",
+        "name": "Scions of the Storm",
+        "warband": "Stormcast Eternals Warrior Chamber",
+        "cost": "battletrait",
+        "description": "After deployment, you can pick a friendly fighter with this battle trait. If that fighter is on the battlefield, remove them from the battlefield. At the start of the second battle round onwards, starting with the attacker, you can place that fighter on the battlefield more than 5\" from each enemy fighter and more than 3\" from each objective and treasure token.",
+        "runemarks": []
     }
 ]

--- a/data/Order/sylvaneth_abilities.json
+++ b/data/Order/sylvaneth_abilities.json
@@ -130,6 +130,14 @@
         "runemarks": []
     },
     {
+        "_id": "d37ba65e",
+        "name": "Spirit Pathways",
+        "warband": "Sylvaneth",
+        "cost": "battletrait",
+        "description": "Once per battle, a friendly fighter with this battle trait can use the 'Walk The Spirit Paths' ability with needing or spending any ability dice, and can use this ability as if they had the Warrior runemark.",
+        "runemarks": []
+    },
+    {
         "_id": "39080dc4",
         "name": "Vigour and Wrath",
         "warband": "Ylthari's Guardians",

--- a/data/Order/twistweald_abilities.json
+++ b/data/Order/twistweald_abilities.json
@@ -13,7 +13,7 @@
         "warband": "Twistweald",
         "cost": "double",
         "description": "During the next melee attack action made by this fighter, critical hits are scored on a 5+ for that attack action.",
-        "runemarks": [ 
+        "runemarks": [
             "destroyer"
         ]
     },
@@ -61,6 +61,14 @@
         "warband": "Twistweald",
         "cost": "quad",
         "description": "Remove a number of damage points allocated to this fighter equal to the value of this ability. This fighter can then make a bonus move action or a bonus attack action.",
+        "runemarks": []
+    },
+    {
+        "_id": "506dca98",
+        "name": "Ravaged by Corruption",
+        "warband": "Twistweald",
+        "cost": "battletrait",
+        "description": "At the end of each battle round, you can choose a friendly fighter with this battle trait that is within 1\" of one or more enemy fighters and roll a dice. On a 2+, allocate 1 damage point to that friendly fighter If that friendly fighter is not take down, pick one of those enemy fighters. Allocated D3 damage points to that enemy fighter.",
         "runemarks": []
     }
 ]

--- a/data/Order/vulkyn_flameseekers_abilities.json
+++ b/data/Order/vulkyn_flameseekers_abilities.json
@@ -62,5 +62,13 @@
         "cost": "quad",
         "description": "Pick a visible enemy fighter within 3\" of this fighter and roll 6 dice. For each roll of 2+, allocate a number of damage points to that fighter equal to half the value of this ability (rounding up).",
         "runemarks": []
+    },
+    {
+        "_id": "81b67ce4",
+        "name": "Vulkyn Flameseekers",
+        "warband": "Vulkyn Flameseekers",
+        "cost": "battletrait",
+        "description": "Friendly fighters with the Berseker runemark can use the following ability:[Triple] Reborn in Flame:Pick a friendly fighter with the Beast runemark that has been taken down. Set that fighter up on a platform or the battlefield floor wholly within 3\" of this fighter. That fighter no longer counts as being taken down. Remove each damage point allocated to that fighter.",
+        "runemarks": []
     }
 ]

--- a/data/Order/wildercorps_hunters_abilities.json
+++ b/data/Order/wildercorps_hunters_abilities.json
@@ -67,5 +67,13 @@
         "runemarks": [
             "warrior"
         ]
+    },
+    {
+        "_id": "1b4d3043",
+        "name": "Point Blank Volley",
+        "warband": "Wildercorps Hunters",
+        "cost": "battletrait",
+        "description": "Once per battle round, before a friendly fighter this with battle trait makes a ranged attack action, you can have them make a point blank volley. When they do so, you can treat the minimum range of that weapon as 1\".",
+        "runemarks": []
     }
 ]

--- a/data/Order/ydrilan_riverblades_abilities.json
+++ b/data/Order/ydrilan_riverblades_abilities.json
@@ -1,58 +1,72 @@
 [
-  {
-    "_id": "25a93cd6",
-    "name": "Lethal Gyre",
-    "warband": "Ydrilan Riverblades",
-    "cost": "reaction",
-    "description": "A fighter can make this reaction after they are targeted by a melee attack action but before the hit rolls are made. For each hit roll of 1 from that attack action, allocate 3 damage points to the attacking fighter, or if this fighter has the Agile runemark, allocate 3 damage points to each enemy fighter within 1\" instead.",
-    "runemarks": []
-  },
-  {
-    "_id": "0e14ad5e",
-    "name": "Riverblades",
-    "warband": "Ydrilan Riverblades",
-    "cost": "double",
-    "description": "Until the end of this fighter's activation, add 1 to this fighter's Move characteristic, and after each action this fighter takes, other than wait actions, roll a dice. On a roll of 2+, deal 1 damage to 1 visible enemy fighter within 8\".",
-    "runemarks": []
-  },
-  {
-    "_id": "ef131c72",
-    "name": "Rapids Rising Leap",
-    "warband": "Ydrilan Riverblades",
-    "cost": "double",
-    "description": "Until the end of this fighter's activation, they can fly when making move actions; however, when flying, they cannot move vertically upwards of more than 3\".",
-    "runemarks": ["elite"]
-  },
-  {
-    "_id": "a553063f",
-    "name": "Whitecrest Strike",
-    "warband": "Ydrilan Riverblades",
-    "cost": "double",
-    "description": "Until the end of this fighter's activation, add 1 to the Strength characteristic of attack actions made by this fighter.",
-    "runemarks": ["hero"]
-  },
-  {
-    "_id": "5254442e",
-    "name": "Standing Wave Stance",
-    "warband": "Ydrilan Riverblades",
-    "cost": "triple",
-    "description": "A fighter can only use this ability if this fighter has not made a move or disengage action this activation, and if a fighter uses this ability they cannot make a move or disengage action this activation. Until the end of this fighter's activation, add 1 to the Attacks and Strength characteristics of melee attack actions made by this fighter, and until the end of the battle round, add 1 to the Toughness characteristic of this fighter.",
-    "runemarks": []
-  },
-  {
-    "_id": "5be919af",
-    "name": "Release the River",
-    "warband": "Ydrilan Riverblades",
-    "cost": "triple",
-    "description": "Until the end of the battle round, add half the value of this ability (rounding up) to the Move characteristic of friendly fighters while they make a move action that starts within 6\" of this fighter.",
-    "runemarks": ["hero"]
-  },
-  {
-    "_id": "988d3836",
-    "name": "Boiling Wrath",
-    "warband": "Ydrilan Riverblades",
-    "cost": "quad",
-    "description": "This fighter makes a number of bonus actions, which may be any combination of move, attack, and disengage actions, equal to the number of fighters from that fighter's battle group that have been taken down.",
-    "runemarks": []
-  }
+    {
+        "_id": "25a93cd6",
+        "name": "Lethal Gyre",
+        "warband": "Ydrilan Riverblades",
+        "cost": "reaction",
+        "description": "A fighter can make this reaction after they are targeted by a melee attack action but before the hit rolls are made. For each hit roll of 1 from that attack action, allocate 3 damage points to the attacking fighter, or if this fighter has the Agile runemark, allocate 3 damage points to each enemy fighter within 1\" instead.",
+        "runemarks": []
+    },
+    {
+        "_id": "0e14ad5e",
+        "name": "Riverblades",
+        "warband": "Ydrilan Riverblades",
+        "cost": "double",
+        "description": "Until the end of this fighter's activation, add 1 to this fighter's Move characteristic, and after each action this fighter takes, other than wait actions, roll a dice. On a roll of 2+, deal 1 damage to 1 visible enemy fighter within 8\".",
+        "runemarks": []
+    },
+    {
+        "_id": "ef131c72",
+        "name": "Rapids Rising Leap",
+        "warband": "Ydrilan Riverblades",
+        "cost": "double",
+        "description": "Until the end of this fighter's activation, they can fly when making move actions; however, when flying, they cannot move vertically upwards of more than 3\".",
+        "runemarks": [
+            "elite"
+        ]
+    },
+    {
+        "_id": "a553063f",
+        "name": "Whitecrest Strike",
+        "warband": "Ydrilan Riverblades",
+        "cost": "double",
+        "description": "Until the end of this fighter's activation, add 1 to the Strength characteristic of attack actions made by this fighter.",
+        "runemarks": [
+            "hero"
+        ]
+    },
+    {
+        "_id": "5254442e",
+        "name": "Standing Wave Stance",
+        "warband": "Ydrilan Riverblades",
+        "cost": "triple",
+        "description": "A fighter can only use this ability if this fighter has not made a move or disengage action this activation, and if a fighter uses this ability they cannot make a move or disengage action this activation. Until the end of this fighter's activation, add 1 to the Attacks and Strength characteristics of melee attack actions made by this fighter, and until the end of the battle round, add 1 to the Toughness characteristic of this fighter.",
+        "runemarks": []
+    },
+    {
+        "_id": "5be919af",
+        "name": "Release the River",
+        "warband": "Ydrilan Riverblades",
+        "cost": "triple",
+        "description": "Until the end of the battle round, add half the value of this ability (rounding up) to the Move characteristic of friendly fighters while they make a move action that starts within 6\" of this fighter.",
+        "runemarks": [
+            "hero"
+        ]
+    },
+    {
+        "_id": "988d3836",
+        "name": "Boiling Wrath",
+        "warband": "Ydrilan Riverblades",
+        "cost": "quad",
+        "description": "This fighter makes a number of bonus actions, which may be any combination of move, attack, and disengage actions, equal to the number of fighters from that fighter's battle group that have been taken down.",
+        "runemarks": []
+    },
+    {
+        "_id": "25eb711b",
+        "name": "The River Winds Its Way",
+        "warband": "Ydrilan Riverblades",
+        "cost": "battletrait",
+        "description": "Add 1 to the Move characteristic of friendly fighters with this battle trait that start a move action within 1\" of a terrain feature and on the battlefield floor until the end of that activation.",
+        "runemarks": []
+    }
 ]

--- a/data/schemas/ability_schema.json
+++ b/data/schemas/ability_schema.json
@@ -35,10 +35,11 @@
 		},
 		"cost": {
 			"type": "string",
-			"description": "passive, reaction, double, triple or quad",
+			"description": "battletrait, passive, reaction, double, triple or quad",
 			"enum": [
+				"battletrait",
 				"passive",
-    "reaction",
+				"reaction",
 				"double",
 				"triple",
 				"quad"

--- a/python/data_parsing/warbands.py
+++ b/python/data_parsing/warbands.py
@@ -1,13 +1,15 @@
-from .fighters import sort_fighters, Fighter, Fighters, FighterJSONDataPayload
-from .abilities import Ability
-from .models import DataPayload, PROJECT_DATA, sanitise_filename, DIST
-from pathlib import Path
-from typing import Union, List, Dict
 import json
-import jsonschema
 import re
 import uuid
 from copy import deepcopy
+from pathlib import Path
+from typing import Union, List, Dict
+
+import jsonschema
+
+from .abilities import Ability
+from .fighters import sort_fighters, Fighter, Fighters, FighterJSONDataPayload
+from .models import DataPayload, PROJECT_DATA, sanitise_filename
 
 
 class WarbandsJSONDataPayload(DataPayload):
@@ -108,7 +110,14 @@ class WarbandsJSONDataPayload(DataPayload):
 
     def write_abilities_to_disk(self, dst: Path = Path(PROJECT_DATA, 'abilities.json')):
         self.validate_data()
-        sorted_data = sorted(self.data['abilities'], key=lambda d: d['warband'])
+        no_battletraits = [x for x in self.data['abilities'] if x['cost'] != 'battletrait']
+        sorted_data = sorted(no_battletraits, key=lambda d: d['warband'])
+        self._write_json(dst=dst, data=sorted_data)
+
+    def write_battletraits_to_disk(self, dst: Path = Path(PROJECT_DATA, 'abilities.json')):
+        self.validate_data()
+        battletraits = [x for x in self.data['abilities'] if x['cost'] == 'battletrait']
+        sorted_data = sorted(battletraits, key=lambda d: d['warband'])
         self._write_json(dst=dst, data=sorted_data)
 
     def write_warbands_to_disk(self, dst: Path = PROJECT_DATA):

--- a/python/export_data.py
+++ b/python/export_data.py
@@ -1,9 +1,10 @@
-from data_parsing.warbands import WarbandsJSONDataPayload
-from data_parsing.models import DIST, LOCALISATION_DATA, LOCAL_DATA
+import argparse
+from dataclasses import dataclass
 from pathlib import Path
 from typing import List
-from dataclasses import dataclass
-import argparse
+
+from data_parsing.models import DIST, LOCALISATION_DATA, LOCAL_DATA
+from data_parsing.warbands import WarbandsJSONDataPayload
 
 
 def get_data_files(data_loc: Path = DIST) -> List[Path]:
@@ -34,6 +35,7 @@ if __name__ == '__main__':
 
     combined_data = WarbandsJSONDataPayload()
     combined_data.write_abilities_to_disk(dst=Path(out_dir, 'abilities.json'))
+    combined_data.write_battletraits_to_disk(dst=Path(out_dir, 'battletraits.json'))
     combined_data.write_fighters_to_disk(dst=Path(out_dir, 'fighters.json'))
     combined_data.write_tts_fighters(dst=Path(out_dir, 'fighters_tts.json'))
     combined_data.write_fighters_html(dst_root=out_dir)


### PR DESCRIPTION
This PR makes the following changes:
- Adds `battletrait` as a valid ability 'cost'
- Adds battletraits from Baz' writeup to each warband file (thanks Baz!)
- Behaviour change so that battletraits are not exported to the existing `abilities.json`, they are exported to `battletraits.json` instead.